### PR TITLE
fix importlib and distutils formatting of platform tag for ARM

### DIFF
--- a/Lib/_osx_support.py
+++ b/Lib/_osx_support.py
@@ -38,7 +38,7 @@ def _find_executable(executable, path=None):
     paths = path.split(os.pathsep)
     base, ext = os.path.splitext(executable)
 
-    if (sys.platform.startswith('win')) and (ext != '.exe'):
+    if (sys.platform == 'win32') and (ext != '.exe'):
         executable = executable + '.exe'
 
     if not os.path.isfile(executable):

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -10,7 +10,7 @@ import stat
 import sys
 # Import _thread instead of threading to reduce startup cost
 from _thread import allocate_lock as Lock
-if sys.platform in {'win32', 'win-arm', 'cygwin'}:
+if sys.platform in {'win32', 'cygwin'}:
     from msvcrt import setmode as _setmode
 else:
     _setmode = None

--- a/Lib/asyncio/__init__.py
+++ b/Lib/asyncio/__init__.py
@@ -35,7 +35,7 @@ __all__ = (base_events.__all__ +
            tasks.__all__ +
            transports.__all__)
 
-if sys.platform.startswith('win'):  # pragma: no cover
+if sys.platform == 'win32':  # pragma: no cover
     from .windows_events import *
     __all__ += windows_events.__all__
 else:

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -32,7 +32,7 @@ __all__ = (
 )
 
 
-if sys.platform.startswith('win'):  # pragma: no cover
+if sys.platform == 'win32':  # pragma: no cover
     raise ImportError('Signals are not really supported on Windows')
 
 

--- a/Lib/asyncio/windows_utils.py
+++ b/Lib/asyncio/windows_utils.py
@@ -2,7 +2,7 @@
 
 import sys
 
-if not sys.platform.startswith('win'):  # pragma: no cover
+if sys.platform != 'win32':  # pragma: no cover
     raise ImportError('win32 only')
 
 import _winapi

--- a/Lib/ctypes/test/test_bytes.py
+++ b/Lib/ctypes/test/test_bytes.py
@@ -52,7 +52,7 @@ class BytesTest(unittest.TestCase):
         self.assertEqual(x.a, "abc")
         self.assertEqual(type(x.a), str)
 
-    @unittest.skipUnless(sys.platform.startswith("win"), 'Windows-specific test')
+    @unittest.skipUnless(sys.platform == "win32", 'Windows-specific test')
     def test_BSTR(self):
         from _ctypes import _SimpleCData
         class BSTR(_SimpleCData):

--- a/Lib/ctypes/test/test_find.py
+++ b/Lib/ctypes/test/test_find.py
@@ -10,7 +10,7 @@ class Test_OpenGL_libs(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         lib_gl = lib_glu = lib_gle = None
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             lib_gl = find_library("OpenGL32")
             lib_glu = find_library("Glu32")
         elif sys.platform == "darwin":

--- a/Lib/ctypes/test/test_functions.py
+++ b/Lib/ctypes/test/test_functions.py
@@ -17,7 +17,7 @@ except NameError:
 
 import _ctypes_test
 dll = CDLL(_ctypes_test.__file__)
-if sys.platform.startswith("win"):
+if sys.platform == "win32":
     windll = WinDLL(_ctypes_test.__file__)
 
 class POINT(Structure):
@@ -341,7 +341,7 @@ class FunctionTestCase(unittest.TestCase):
         s2h = dll.ret_2h_func(inp)
         self.assertEqual((s2h.x, s2h.y), (99*2, 88*3))
 
-    @unittest.skipUnless(sys.platform.startswith("win"), 'Windows-specific test')
+    @unittest.skipUnless(sys.platform == "win32", 'Windows-specific test')
     def test_struct_return_2H_stdcall(self):
         class S2H(Structure):
             _fields_ = [("x", c_short),
@@ -369,7 +369,7 @@ class FunctionTestCase(unittest.TestCase):
         self.assertEqual((s8i.a, s8i.b, s8i.c, s8i.d, s8i.e, s8i.f, s8i.g, s8i.h),
                              (9*2, 8*3, 7*4, 6*5, 5*6, 4*7, 3*8, 2*9))
 
-    @unittest.skipUnless(sys.platform.startswith("win"), 'Windows-specific test')
+    @unittest.skipUnless(sys.platform == "win32", 'Windows-specific test')
     def test_struct_return_8H_stdcall(self):
         class S8I(Structure):
             _fields_ = [("a", c_int),

--- a/Lib/ctypes/test/test_pointers.py
+++ b/Lib/ctypes/test/test_pointers.py
@@ -192,7 +192,7 @@ class PointersTestCase(unittest.TestCase):
         self.assertEqual(bool(CFUNCTYPE(None)(42)), True)
 
         # COM methods are boolean True:
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             mth = WINFUNCTYPE(None)(42, "name", (), None)
             self.assertEqual(bool(mth), True)
 

--- a/Lib/ctypes/test/test_random_things.py
+++ b/Lib/ctypes/test/test_random_things.py
@@ -5,7 +5,7 @@ def callback_func(arg):
     42 / arg
     raise ValueError(arg)
 
-@unittest.skipUnless(sys.platform.startswith("win"), 'Windows-specific test')
+@unittest.skipUnless(sys.platform == "win32", 'Windows-specific test')
 class call_function_TestCase(unittest.TestCase):
     # _ctypes.call_function is deprecated and private, but used by
     # Gary Bishp's readline module.  If we have it, we must test it as well.

--- a/Lib/ctypes/test/test_win32.py
+++ b/Lib/ctypes/test/test_win32.py
@@ -7,7 +7,7 @@ from test import support
 import _ctypes_test
 
 # Only windows 32-bit has different calling conventions.
-@unittest.skipUnless(sys.platform.startswith("win"), 'Windows-specific test')
+@unittest.skipUnless(sys.platform == "win32", 'Windows-specific test')
 @unittest.skipUnless(sizeof(c_void_p) == sizeof(c_int),
                      "sizeof c_void_p and c_int differ")
 class WindowsTestCase(unittest.TestCase):
@@ -37,7 +37,7 @@ class WindowsTestCase(unittest.TestCase):
         # (4 bytes missing) or wrong calling convention
         self.assertRaises(ValueError, IsWindow, None)
 
-@unittest.skipUnless(sys.platform.startswith("win"), 'Windows-specific test')
+@unittest.skipUnless(sys.platform == "win32", 'Windows-specific test')
 class FunctionCallTestCase(unittest.TestCase):
     @unittest.skipUnless('MSC' in sys.version, "SEH only supported by MSC")
     @unittest.skipIf(sys.executable.lower().endswith('_d.exe'),
@@ -56,7 +56,7 @@ class FunctionCallTestCase(unittest.TestCase):
         windll.user32.GetDesktopWindow()
 
 
-@unittest.skipUnless(sys.platform.startswith("win"), 'Windows-specific test')
+@unittest.skipUnless(sys.platform == "win32", 'Windows-specific test')
 class TestWintypes(unittest.TestCase):
     def test_HWND(self):
         from ctypes import wintypes
@@ -80,7 +80,7 @@ class TestWintypes(unittest.TestCase):
         self.assertEqual(ex.text, "text")
         self.assertEqual(ex.details, ("details",))
 
-@unittest.skipUnless(sys.platform.startswith("win"), 'Windows-specific test')
+@unittest.skipUnless(sys.platform == "win32", 'Windows-specific test')
 class TestWinError(unittest.TestCase):
     def test_winerror(self):
         # see Issue 16169

--- a/Lib/distutils/archive_util.py
+++ b/Lib/distutils/archive_util.py
@@ -115,7 +115,7 @@ def make_tarball(base_name, base_dir, compress="gzip", verbose=0, dry_run=0,
         warn("'compress' will be deprecated.", PendingDeprecationWarning)
         # the option varies depending on the platform
         compressed_name = archive_name + compress_ext[compress]
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             cmd = [compress, archive_name, compressed_name]
         else:
             cmd = [compress, '-f', archive_name]

--- a/Lib/distutils/command/bdist_wininst.py
+++ b/Lib/distutils/command/bdist_wininst.py
@@ -110,7 +110,7 @@ class bdist_wininst(Command):
                       % self.install_script)
 
     def run(self):
-        if (not sys.platform.startswith("win") and
+        if (sys.platform != "win32" and
             (self.distribution.has_ext_modules() or
              self.distribution.has_c_libraries())):
             raise DistutilsPlatformError \

--- a/Lib/distutils/command/build_ext.py
+++ b/Lib/distutils/command/build_ext.py
@@ -702,7 +702,7 @@ class build_ext(Command):
         # pyconfig.h that MSVC groks.  The other Windows compilers all seem
         # to need it mentioned explicitly, though, so that's what we do.
         # Append '_d' to the python import library on debug builds.
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             from distutils._msvccompiler import MSVCCompiler
             if not isinstance(self.compiler, MSVCCompiler):
                 template = "python%d%d"

--- a/Lib/distutils/command/sdist.py
+++ b/Lib/distutils/command/sdist.py
@@ -364,7 +364,7 @@ class sdist(Command):
         self.filelist.exclude_pattern(None, prefix=build.build_base)
         self.filelist.exclude_pattern(None, prefix=base_dir)
 
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             seps = r'/|\\'
         else:
             seps = '/'

--- a/Lib/distutils/msvc9compiler.py
+++ b/Lib/distutils/msvc9compiler.py
@@ -36,7 +36,7 @@ HKEYS = (winreg.HKEY_USERS,
          winreg.HKEY_LOCAL_MACHINE,
          winreg.HKEY_CLASSES_ROOT)
 
-NATIVE_WIN64 = (sys.platform.startswith('win') and sys.maxsize > 2**32)
+NATIVE_WIN64 = (sys.platform == 'win32' and sys.maxsize > 2**32)
 if NATIVE_WIN64:
     # Visual C++ is a 32-bit application, so we need to look in
     # the corresponding registry branch, if we're running a

--- a/Lib/distutils/spawn.py
+++ b/Lib/distutils/spawn.py
@@ -178,7 +178,7 @@ def find_executable(executable, path=None):
     paths = path.split(os.pathsep)
     base, ext = os.path.splitext(executable)
 
-    if (sys.platform.startswith('win')) and (ext != '.exe'):
+    if (sys.platform == 'win32') and (ext != '.exe'):
         executable = executable + '.exe'
 
     if not os.path.isfile(executable):

--- a/Lib/distutils/tests/test_bdist_msi.py
+++ b/Lib/distutils/tests/test_bdist_msi.py
@@ -6,7 +6,7 @@ from test.support import run_unittest
 from distutils.tests import support
 
 
-SKIP_MESSAGE = (None if sys.platform.startswith("win") and not platform.win32_is_iot() else
+SKIP_MESSAGE = (None if sys.platform == 'win32' and not platform.win32_is_iot() else
                 "These tests require Windows x86 or x64.  Windows IoT Core and nanoserver are not supported")
 
 @unittest.skipUnless(SKIP_MESSAGE is None, SKIP_MESSAGE)

--- a/Lib/distutils/tests/test_build_clib.py
+++ b/Lib/distutils/tests/test_build_clib.py
@@ -102,7 +102,7 @@ class BuildCLibTestCase(support.TempdirManager,
         cmd.distribution.libraries = 'WONTWORK'
         self.assertRaises(DistutilsSetupError, cmd.finalize_options)
 
-    @unittest.skipIf(sys.platform.startswith('win'), "can't test on Windows")
+    @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
     def test_run(self):
         pkg_dir, dist = self.create_dist()
         cmd = build_clib(dist)

--- a/Lib/distutils/tests/test_config_cmd.py
+++ b/Lib/distutils/tests/test_config_cmd.py
@@ -37,7 +37,7 @@ class ConfigTestCase(support.LoggingSilencer,
         dump_file(this_file, 'I am the header')
         self.assertEqual(len(self._logs), numlines+1)
 
-    @unittest.skipIf(sys.platform.startswith('win'), "can't test on Windows")
+    @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
     def test_search_cpp(self):
         cmd = missing_compiler_executable(['preprocessor'])
         if cmd is not None:

--- a/Lib/distutils/tests/test_dist.py
+++ b/Lib/distutils/tests/test_dist.py
@@ -461,7 +461,7 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
                 self.assertIn(user_filename, files)
 
             # win32-style
-            if sys.platform.startswith('win'):
+            if sys.platform == 'win32':
                 # home drive should be found
                 os.environ['HOME'] = temp_dir
                 files = dist.find_config_files()

--- a/Lib/distutils/tests/test_msvc9compiler.py
+++ b/Lib/distutils/tests/test_msvc9compiler.py
@@ -91,7 +91,7 @@ _CLEANED_MANIFEST = """\
   </dependency>
 </assembly>"""
 
-if sys.platform.startswith("win") and not platform.win32_is_iot():
+if sys.platform=="win32" and not platform.win32_is_iot():
     from distutils.msvccompiler import get_build_version
     if get_build_version()>=8.0:
         SKIP_MESSAGE = None

--- a/Lib/distutils/tests/test_msvccompiler.py
+++ b/Lib/distutils/tests/test_msvccompiler.py
@@ -9,7 +9,7 @@ from distutils.tests import support
 from test.support import run_unittest
 
 
-SKIP_MESSAGE = (None if sys.platform.startswith("win") and not platform.win32_is_iot() else
+SKIP_MESSAGE = (None if sys.platform == "win32" and not platform.win32_is_iot() else
                 "These tests require Windows x86 or x64.  Windows IoT Core and nanoserver are not supported")
 
 @unittest.skipUnless(SKIP_MESSAGE is None, SKIP_MESSAGE)

--- a/Lib/distutils/tests/test_spawn.py
+++ b/Lib/distutils/tests/test_spawn.py
@@ -30,7 +30,7 @@ class SpawnTestCase(support.TempdirManager,
 
         # creating something executable
         # through the shell that returns 1
-        if not sys.platform.startswith('win'):
+        if sys.platform != 'win32':
             exe = os.path.join(tmpdir, 'foo.sh')
             self.write_file(exe, '#!%s\nexit 1' % unix_shell)
         else:
@@ -41,7 +41,7 @@ class SpawnTestCase(support.TempdirManager,
         self.assertRaises(DistutilsExecError, spawn, [exe])
 
         # now something that works
-        if not sys.platform.startswith('win'):
+        if sys.platform != 'win32':
             exe = os.path.join(tmpdir, 'foo.sh')
             self.write_file(exe, '#!%s\nexit 0' % unix_shell)
         else:

--- a/Lib/distutils/tests/test_unixccompiler.py
+++ b/Lib/distutils/tests/test_unixccompiler.py
@@ -20,7 +20,7 @@ class UnixCCompilerTestCase(unittest.TestCase):
         sys.platform = self._backup_platform
         sysconfig.get_config_var = self._backup_get_config_var
 
-    @unittest.skipIf(sys.platform.startswith('win'), "can't test on Windows")
+    @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
     def test_runtime_libdir_option(self):
         # Issue#5900
         #

--- a/Lib/distutils/util.py
+++ b/Lib/distutils/util.py
@@ -38,7 +38,7 @@ def get_platform ():
     if os.name == 'nt':
         if 'amd64' in sys.version.lower():
             return 'win-amd64'
-        if '(arm)' in sys.version.lower():
+        if 'arm' in sys.version.lower():
             return 'win-arm'
         return sys.platform
 

--- a/Lib/distutils/util.py
+++ b/Lib/distutils/util.py
@@ -38,6 +38,8 @@ def get_platform ():
     if os.name == 'nt':
         if 'amd64' in sys.version.lower():
             return 'win-amd64'
+        if '(arm)' in sys.version.lower():
+            return 'win-arm'
         return sys.platform
 
     # Set for cross builds explicitly

--- a/Lib/encodings/__init__.py
+++ b/Lib/encodings/__init__.py
@@ -155,7 +155,7 @@ def search_function(encoding):
 # Register the search_function in the Python codec registry
 codecs.register(search_function)
 
-if sys.platform.startswith('win'):
+if sys.platform == 'win32':
     def _alias_mbcs(encoding):
         try:
             import _winapi

--- a/Lib/idlelib/iomenu.py
+++ b/Lib/idlelib/iomenu.py
@@ -25,7 +25,7 @@ else:
         pass
 
     locale_decode = 'ascii'
-    if sys.platform.startswith('win'):
+    if sys.platform == 'win32':
         # On Windows, we could use "mbcs". However, to give the user
         # a portable encoding name, we need to find the code page
         try:

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -11,7 +11,7 @@ except ImportError:
 
 # Valid arguments for the ...Awareness call below are defined in the following.
 # https://msdn.microsoft.com/en-us/library/windows/desktop/dn280512(v=vs.85).aspx
-if sys.platform.startswith('win'):
+if sys.platform == 'win32':
     import ctypes
     PROCESS_SYSTEM_DPI_AWARE = 1
     try:

--- a/Lib/idlelib/zoomheight.py
+++ b/Lib/idlelib/zoomheight.py
@@ -25,7 +25,7 @@ def zoom_height(top):
         return
     width, height, x, y = map(int, m.groups())
     newheight = top.winfo_screenheight()
-    if sys.platform.startswith('win'):
+    if sys.platform == 'win32':
         newy = 0
         newheight = newheight - 72
 

--- a/Lib/locale.py
+++ b/Lib/locale.py
@@ -547,7 +547,7 @@ def getdefaultlocale(envvars=('LC_ALL', 'LC_CTYPE', 'LANG', 'LANGUAGE')):
         pass
     else:
         # make sure the code/encoding values are valid
-        if sys.platform.startswith("win") and code and code[:2] == "0x":
+        if sys.platform == "win32" and code and code[:2] == "0x":
             # map windows language identifier to language name
             code = windows_locale.get(int(code, 0))
         # ...add other platform-specific processing here, if

--- a/Lib/multiprocessing/connection.py
+++ b/Lib/multiprocessing/connection.py
@@ -30,7 +30,7 @@ try:
     import _winapi
     from _winapi import WAIT_OBJECT_0, WAIT_ABANDONED_0, WAIT_TIMEOUT, INFINITE
 except ImportError:
-    if sys.platform.startswith('win'):
+    if sys.platform == 'win32':
         raise
     _winapi = None
 
@@ -51,7 +51,7 @@ if hasattr(socket, 'AF_UNIX'):
     default_family = 'AF_UNIX'
     families += ['AF_UNIX']
 
-if sys.platform.startswith('win'):
+if sys.platform == 'win32':
     default_family = 'AF_PIPE'
     families += ['AF_PIPE']
 
@@ -84,10 +84,10 @@ def _validate_family(family):
     '''
     Checks if the family is valid for the current environment.
     '''
-    if not sys.platform.startswith('win') and family == 'AF_PIPE':
+    if sys.platform != 'win32' and family == 'AF_PIPE':
         raise ValueError('Family %s is not recognized.' % family)
 
-    if sys.platform.startswith('win') and family == 'AF_UNIX':
+    if sys.platform == 'win32' and family == 'AF_UNIX':
         # double check
         if not hasattr(socket, family):
             raise ValueError('Family %s is not recognized.' % family)
@@ -501,7 +501,7 @@ def Client(address, family=None, authkey=None):
     return c
 
 
-if not sys.platform.startswith('win'):
+if sys.platform != 'win32':
 
     def Pipe(duplex=True):
         '''
@@ -623,7 +623,7 @@ def SocketClient(address):
 # Definitions for connections based on named pipes
 #
 
-if sys.platform.startswith('win'):
+if sys.platform == 'win32':
 
     class PipeListener(object):
         '''
@@ -789,7 +789,7 @@ def XmlClient(*args, **kwds):
 # Wait
 #
 
-if sys.platform.startswith('win'):
+if sys.platform == 'win32':
 
     def _exhaustive_wait(handles, timeout):
         # Return ALL handles which are currently signalled.  (Only
@@ -930,7 +930,7 @@ else:
 # Make connection and socket objects sharable if possible
 #
 
-if sys.platform.startswith('win'):
+if sys.platform == 'win32':
     def reduce_connection(conn):
         handle = conn.fileno()
         with socket.fromfd(handle, socket.AF_INET, socket.SOCK_STREAM) as s:

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -144,7 +144,7 @@ class BaseContext(object):
         '''Check whether this is a fake forked process in a frozen executable.
         If so then run code specified by commandline and exit.
         '''
-        if sys.platform.startswith('win') and getattr(sys, 'frozen', False):
+        if sys.platform == 'win32' and getattr(sys, 'frozen', False):
             from .spawn import freeze_support
             freeze_support()
 
@@ -253,7 +253,7 @@ class DefaultContext(BaseContext):
         return self._actual_context._name
 
     def get_all_start_methods(self):
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             return ['spawn']
         else:
             if reduction.HAVE_SEND_HANDLE:
@@ -267,7 +267,7 @@ DefaultContext.__all__ = [x for x in dir(DefaultContext) if x[0] != '_']
 # Context types for fixed start method
 #
 
-if not sys.platform.startswith('win'):
+if sys.platform != 'win32':
 
     class ForkProcess(process.BaseProcess):
         _start_method = 'fork'

--- a/Lib/multiprocessing/heap.py
+++ b/Lib/multiprocessing/heap.py
@@ -23,7 +23,7 @@ __all__ = ['BufferWrapper']
 # Inheritable class which wraps an mmap, and from which blocks can be allocated
 #
 
-if sys.platform.startswith('win'):
+if sys.platform == 'win32':
 
     import _winapi
 

--- a/Lib/multiprocessing/popen_spawn_win32.py
+++ b/Lib/multiprocessing/popen_spawn_win32.py
@@ -15,7 +15,7 @@ __all__ = ['Popen']
 #
 
 TERMINATE = 0x10000
-WINEXE = (sys.platform.startswith('win') and getattr(sys, 'frozen', False))
+WINEXE = (sys.platform == 'win32' and getattr(sys, 'frozen', False))
 WINSERVICE = sys.executable.lower().endswith("pythonservice.exe")
 
 #

--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -41,7 +41,7 @@ class Queue(object):
         self._reader, self._writer = connection.Pipe(duplex=False)
         self._rlock = ctx.Lock()
         self._opid = os.getpid()
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             self._wlock = None
         else:
             self._wlock = ctx.Lock()
@@ -51,7 +51,7 @@ class Queue(object):
 
         self._after_fork()
 
-        if not sys.platform.startswith('win'):
+        if sys.platform != 'win32':
             register_after_fork(self, Queue._after_fork)
 
     def __getstate__(self):
@@ -210,7 +210,7 @@ class Queue(object):
         nwait = notempty.wait
         bpopleft = buffer.popleft
         sentinel = _sentinel
-        if not sys.platform.startswith('win'):
+        if sys.platform != 'win32':
             wacquire = writelock.acquire
             wrelease = writelock.release
         else:
@@ -331,7 +331,7 @@ class SimpleQueue(object):
         self._reader, self._writer = connection.Pipe(duplex=False)
         self._rlock = ctx.Lock()
         self._poll = self._reader.poll
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             self._wlock = None
         else:
             self._wlock = ctx.Lock()

--- a/Lib/multiprocessing/reduction.py
+++ b/Lib/multiprocessing/reduction.py
@@ -21,7 +21,7 @@ from . import context
 __all__ = ['send_handle', 'recv_handle', 'ForkingPickler', 'register', 'dump']
 
 
-HAVE_SEND_HANDLE = (sys.platform.startswith('win') or
+HAVE_SEND_HANDLE = (sys.platform == 'win32' or
                     (hasattr(socket, 'CMSG_LEN') and
                      hasattr(socket, 'SCM_RIGHTS') and
                      hasattr(socket.socket, 'sendmsg')))
@@ -63,7 +63,7 @@ def dump(obj, file, protocol=None):
 # Platform specific definitions
 #
 
-if sys.platform.startswith('win'):
+if sys.platform == 'win32':
     # Windows
     __all__ += ['DupHandle', 'duplicate', 'steal_handle']
     import _winapi
@@ -226,7 +226,7 @@ register(functools.partial, _reduce_partial)
 # Make sockets picklable
 #
 
-if sys.platform.startswith('win'):
+if sys.platform == 'win32':
     def _reduce_socket(s):
         from .resource_sharer import DupSocket
         return _rebuild_socket, (DupSocket(s),)
@@ -254,7 +254,7 @@ class AbstractReducer(metaclass=ABCMeta):
     send_handle = send_handle
     recv_handle = recv_handle
 
-    if sys.platform.startswith('win'):
+    if sys.platform == 'win32':
         steal_handle = steal_handle
         duplicate = duplicate
         DupHandle = DupHandle

--- a/Lib/multiprocessing/resource_sharer.py
+++ b/Lib/multiprocessing/resource_sharer.py
@@ -21,7 +21,7 @@ from . import util
 __all__ = ['stop']
 
 
-if sys.platform.startswith('win'):
+if sys.platform == 'win32':
     __all__ += ['DupSocket']
 
     class DupSocket(object):

--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -26,11 +26,11 @@ __all__ = ['_main', 'freeze_support', 'set_executable', 'get_executable',
 # People embedding Python want to modify it.
 #
 
-if not sys.platform.startswith('win'):
+if sys.platform != 'win32':
     WINEXE = False
     WINSERVICE = False
 else:
-    WINEXE = (sys.platform.startswith('win') and getattr(sys, 'frozen', False))
+    WINEXE = (sys.platform == 'win32' and getattr(sys, 'frozen', False))
     WINSERVICE = sys.executable.lower().endswith("pythonservice.exe")
 
 if WINSERVICE:
@@ -94,7 +94,7 @@ def spawn_main(pipe_handle, parent_pid=None, tracker_fd=None):
     Run code specified by data received over pipe
     '''
     assert is_forking(sys.argv), "Not forking"
-    if sys.platform.startswith('win'):
+    if sys.platform == 'win32':
         import msvcrt
         new_handle = reduction.steal_handle(parent_pid, pipe_handle)
         fd = msvcrt.open_osfhandle(new_handle, os.O_RDONLY)
@@ -172,7 +172,7 @@ def get_preparation_data(name):
     main_mod_name = getattr(main_module.__spec__, "name", None)
     if main_mod_name is not None:
         d['init_main_from_name'] = main_mod_name
-    elif not sys.platform.startswith('win') or (not WINEXE and not WINSERVICE):
+    elif sys.platform != 'win32' or (not WINEXE and not WINSERVICE):
         main_path = getattr(main_module, '__file__', None)
         if main_path is not None:
             if (not os.path.isabs(main_path) and

--- a/Lib/multiprocessing/synchronize.py
+++ b/Lib/multiprocessing/synchronize.py
@@ -51,7 +51,7 @@ class SemLock(object):
         if ctx is None:
             ctx = context._default_context.get_context()
         name = ctx.get_start_method()
-        unlink_now = sys.platform.startswith('win') or name == 'fork'
+        unlink_now = sys.platform == 'win32' or name == 'fork'
         for i in range(100):
             try:
                 sl = self._semlock = _multiprocessing.SemLock(
@@ -67,7 +67,7 @@ class SemLock(object):
         util.debug('created semlock with handle %s' % sl.handle)
         self._make_methods()
 
-        if not sys.platform.startswith('win'):
+        if sys.platform != 'win32':
             def _after_fork(obj):
                 obj._semlock._after_fork()
             util.register_after_fork(self, _after_fork)
@@ -100,7 +100,7 @@ class SemLock(object):
     def __getstate__(self):
         context.assert_spawning(self)
         sl = self._semlock
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             h = context.get_spawning_popen().duplicate_for_child(sl.handle)
         else:
             h = sl.handle

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -125,7 +125,7 @@ try:
 except AttributeError:
     # os.devnull was added in Python 2.4, so emulate it for earlier
     # Python versions
-    if sys.platform in ('dos', 'win32', 'win-arm', 'win16'):
+    if sys.platform in ('dos', 'win32', 'win16'):
         # Use the old CP/M NUL as device name
         DEV_NULL = 'NUL'
     else:
@@ -423,7 +423,7 @@ _ver_output = re.compile(r'(?:([\w ]+) ([\w.]+) '
 
 def _syscmd_ver(system='', release='', version='',
 
-               supported_platforms=('win32', 'win-arm', 'win16', 'dos')):
+               supported_platforms=('win32', 'win16', 'dos')):
 
     """ Tries to figure out the OS version used and returns
         a tuple (system, release, version).
@@ -704,7 +704,7 @@ def system_alias(system, release, version):
         else:
             version = '64bit'
 
-    elif system in ('win32', 'win-arm', 'win16'):
+    elif system in ('win32', 'win16'):
         # In case one of the other tricks
         system = 'Windows'
 
@@ -774,7 +774,7 @@ def _syscmd_uname(option, default=''):
 
     """ Interface to the system's uname command.
     """
-    if sys.platform in ('dos', 'win32', 'win-arm', 'win16'):
+    if sys.platform in ('dos', 'win32', 'win16'):
         # XXX Others too ?
         return default
     try:
@@ -797,7 +797,7 @@ def _syscmd_file(target, default=''):
         default in case the command should fail.
 
     """
-    if sys.platform in ('dos', 'win32', 'win-arm', 'win16'):
+    if sys.platform in ('dos', 'win32', 'win16'):
         # XXX Others too ?
         return default
     target = _follow_symlinks(target)
@@ -820,7 +820,6 @@ def _syscmd_file(target, default=''):
 # defaults given as parameters
 _default_architecture = {
     'win32': ('', 'WindowsPE'),
-    'win-arm': ('', 'WindowsPE'),
     'win16': ('', 'Windows'),
     'dos': ('', 'MSDOS'),
 }
@@ -953,7 +952,7 @@ def uname():
         use_syscmd_ver = 1
 
         # Try win32_ver() on win32 platforms
-        if system.startswith('win'):
+        if system == 'win32':
             release, version, csd, ptype = win32_ver()
             if release and version:
                 use_syscmd_ver = 0
@@ -991,9 +990,9 @@ def uname():
 
         # In case we still don't know anything useful, we'll try to
         # help ourselves
-        if system in ('win32', 'win-arm', 'win16'):
+        if system in ('win32', 'win16'):
             if not version:
-                if system == 'win32' or system == 'win-arm':
+                if system == 'win32':
                     version = '32bit'
                 else:
                     version = '16bit'

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1460,7 +1460,7 @@ def getpager():
         return plainpager
     use_pager = os.environ.get('MANPAGER') or os.environ.get('PAGER')
     if use_pager:
-        if sys.platform.startswith('win'): # pipes completely broken in Windows
+        if sys.platform == 'win32': # pipes completely broken in Windows
             return lambda text: tempfilepager(plain(text), use_pager)
         elif os.environ.get('TERM') in ('dumb', 'emacs'):
             return lambda text: pipepager(plain(text), use_pager)
@@ -1468,7 +1468,7 @@ def getpager():
             return lambda text: pipepager(text, use_pager)
     if os.environ.get('TERM') in ('dumb', 'emacs'):
         return plainpager
-    if sys.platform.startswith('win'):
+    if sys.platform == 'win32':
         return lambda text: tempfilepager(plain(text), 'more <')
     if hasattr(os, 'system') and os.system('(less) 2>/dev/null') == 0:
         return lambda text: pipepager(text, 'less')

--- a/Lib/selectors.py
+++ b/Lib/selectors.py
@@ -309,7 +309,7 @@ class SelectSelector(_BaseSelectorImpl):
         self._writers.discard(key.fd)
         return key
 
-    if sys.platform.startswith('win'):
+    if sys.platform == 'win32':
         def _select(self, r, w, _, timeout=None):
             r, w, x = select.select(r, w, w, timeout)
             return r, w + x, []

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -1137,7 +1137,7 @@ def which(cmd, mode=os.F_OK | os.X_OK, path=None):
         return None
     path = path.split(os.pathsep)
 
-    if sys.platform.startswith("win"):
+    if sys.platform == "win32":
         # The current directory takes precedence on Windows.
         if not os.curdir in path:
             path.insert(0, os.curdir)

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -165,7 +165,7 @@ class TLSVersion(_IntEnum):
     MAXIMUM_SUPPORTED = _ssl.PROTO_MAXIMUM_SUPPORTED
 
 
-if sys.platform.startswith("win"):
+if sys.platform == "win32":
     from _ssl import enum_certificates, enum_crls
 
 from socket import socket, AF_INET, SOCK_STREAM, create_connection
@@ -474,7 +474,7 @@ class SSLContext(_SSLContext):
     def load_default_certs(self, purpose=Purpose.SERVER_AUTH):
         if not isinstance(purpose, _ASN1Object):
             raise TypeError(purpose)
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             for storename in self._windows_cert_stores:
                 self._load_windows_store_certs(storename, purpose)
         self.set_default_verify_paths()

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -42,7 +42,7 @@ getstatusoutput(...): Runs a command in the shell, waits for it to complete,
 """
 
 import sys
-_mswindows = (sys.platform.startswith("win"))
+_mswindows = (sys.platform == "win32")
 
 import io
 import os

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -619,6 +619,8 @@ def get_platform():
     if os.name == 'nt':
         if 'amd64' in sys.version.lower():
             return 'win-amd64'
+        if '(arm)' in sys.version.lower():
+            return 'win-arm'
         return sys.platform
 
     if os.name != "posix" or not hasattr(os, 'uname'):

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -619,7 +619,7 @@ def get_platform():
     if os.name == 'nt':
         if 'amd64' in sys.version.lower():
             return 'win-amd64'
-        if '(arm)' in sys.version.lower():
+        if 'arm' in sys.version.lower():
             return 'win-arm'
         return sys.platform
 

--- a/Lib/telnetlib.py
+++ b/Lib/telnetlib.py
@@ -534,7 +534,7 @@ class Telnet:
 
     def interact(self):
         """Interaction function, emulates a very dumb telnet client."""
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             self.mt_interact()
             return
         with _TelnetSelector() as selector:

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -103,7 +103,7 @@ else:
 HAVE_GETVALUE = not getattr(_multiprocessing,
                             'HAVE_BROKEN_SEM_GETVALUE', False)
 
-WIN32 = (sys.platform.startswith("win"))
+WIN32 = (sys.platform == "win32")
 
 from multiprocessing.connection import wait
 
@@ -1474,7 +1474,7 @@ class _TestCondition(BaseTestCase):
             os.kill(pid, signal.SIGINT)
 
     def test_wait_result(self):
-        if isinstance(self, ProcessesMixin) and not sys.platform.startswith('win'):
+        if isinstance(self, ProcessesMixin) and sys.platform != 'win32':
             pid = os.getpid()
         else:
             pid = None
@@ -3020,7 +3020,7 @@ class _TestConnection(BaseTestCase):
             self.assertEqual(f.read(), b"foo")
 
     @unittest.skipUnless(HAS_REDUCTION, "test needs multiprocessing.reduction")
-    @unittest.skipIf(sys.platform.startswith("win"),
+    @unittest.skipIf(sys.platform == "win32",
                      "test semantics don't make sense on Windows")
     @unittest.skipIf(MAXFD <= 256,
                      "largest assignable fd number is too small")
@@ -3057,7 +3057,7 @@ class _TestConnection(BaseTestCase):
         os.write(conn.fileno(), b"\0")
 
     @unittest.skipUnless(HAS_REDUCTION, "test needs multiprocessing.reduction")
-    @unittest.skipIf(sys.platform.startswith("win"), "doesn't make sense on Windows")
+    @unittest.skipIf(sys.platform == "win32", "doesn't make sense on Windows")
     def test_missing_fd_transfer(self):
         # Check that exception is raised when received data is not
         # accompanied by a file descriptor in ancillary data.
@@ -3645,7 +3645,7 @@ class _TestImportStar(unittest.TestCase):
 
     def test_import(self):
         modules = self.get_module_names()
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             modules.remove('multiprocessing.popen_fork')
             modules.remove('multiprocessing.popen_forkserver')
             modules.remove('multiprocessing.popen_spawn_posix')
@@ -4418,7 +4418,7 @@ class TestStartMethod(unittest.TestCase):
 
     def test_get_all(self):
         methods = multiprocessing.get_all_start_methods()
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             self.assertEqual(methods, ['spawn'])
         else:
             self.assertTrue(methods == ['fork', 'spawn'] or
@@ -4437,7 +4437,7 @@ class TestStartMethod(unittest.TestCase):
             self.fail("failed spawning forkserver or grandchild")
 
 
-@unittest.skipIf(sys.platform.startswith("win"),
+@unittest.skipIf(sys.platform == "win32",
                  "test semantics don't make sense on Windows")
 class TestSemaphoreTracker(unittest.TestCase):
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -2249,13 +2249,13 @@ class TestDateTime(TestDate):
             self.assertRaises(OverflowError, self.theclass.utcfromtimestamp,
                               insane)
 
-    @unittest.skipIf(sys.platform.startswith("win"), "Windows doesn't accept negative timestamps")
+    @unittest.skipIf(sys.platform == "win32", "Windows doesn't accept negative timestamps")
     def test_negative_float_fromtimestamp(self):
         # The result is tz-dependent; at least test that this doesn't
         # fail (like it did before bug 1646728 was fixed).
         self.theclass.fromtimestamp(-1.05)
 
-    @unittest.skipIf(sys.platform.startswith("win"), "Windows doesn't accept negative timestamps")
+    @unittest.skipIf(sys.platform == "win32", "Windows doesn't accept negative timestamps")
     def test_negative_float_utcfromtimestamp(self):
         d = self.theclass.utcfromtimestamp(-1.05)
         self.assertEqual(d, self.theclass(1969, 12, 31, 23, 59, 58, 950000))
@@ -5346,7 +5346,7 @@ class ZoneInfoTest(unittest.TestCase):
     zonename = 'America/New_York'
 
     def setUp(self):
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             self.skipTest("Skipping zoneinfo tests on Windows")
         try:
             self.tz = ZoneInfo.fromname(self.zonename)

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -791,7 +791,7 @@ is_jython = sys.platform.startswith('java')
 
 is_android = hasattr(sys, 'getandroidapilevel')
 
-if not sys.platform.startswith('win'):
+if sys.platform != 'win32':
     unix_shell = '/system/bin/sh' if is_android else '/bin/sh'
 else:
     unix_shell = None
@@ -1981,7 +1981,7 @@ def _check_docstrings():
     """Just used to check if docstrings are enabled"""
 
 MISSING_C_DOCSTRINGS = (check_impl_detail() and
-                        not sys.platform.startswith('win') and
+                        sys.platform != 'win32' and
                         not sysconfig.get_config_var('WITH_DOC_STRINGS'))
 
 HAVE_DOCSTRINGS = (_check_docstrings.__doc__ is not None and
@@ -2781,7 +2781,7 @@ def fd_count():
             pass
 
     old_modes = None
-    if sys.platform.startswith('win'):
+    if sys.platform == 'win32':
         # bpo-25306, bpo-31009: Call CrtSetReportMode() to not kill the process
         # on invalid file descriptor if Python is compiled in debug mode
         try:

--- a/Lib/test/support/script_helper.py
+++ b/Lib/test/support/script_helper.py
@@ -105,7 +105,7 @@ def run_python_until_end(*args, **env_vars):
     # caller is responsible to pass the full environment.
     if env_vars.pop('__cleanenv', None):
         env = {}
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             # Windows requires at least the SYSTEMROOT environment variable to
             # start Python.
             env['SYSTEMROOT'] = os.environ['SYSTEMROOT']

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -23,7 +23,7 @@ import unittest
 from unittest import mock
 import weakref
 
-if not sys.platform.startswith('win'):
+if sys.platform != 'win32':
     import tty
 
 import asyncio
@@ -835,7 +835,7 @@ class EventLoopTestsMixin:
 
     @unittest.skipIf(ssl is None, 'No ssl module')
     def test_ssl_connect_accepted_socket(self):
-        if (sys.platform.startswith('win') and
+        if (sys.platform == 'win32' and
             sys.version_info < (3, 5) and
             isinstance(self.loop, proactor_events.BaseProactorEventLoop)
             ):
@@ -1381,7 +1381,7 @@ class EventLoopTestsMixin:
         server.transport.close()
 
     def test_create_datagram_endpoint_sock(self):
-        if (sys.platform.startswith('win') and
+        if (sys.platform == 'win32' and
                 isinstance(self.loop, proactor_events.BaseProactorEventLoop)):
             raise unittest.SkipTest(
                 'UDP is not supported with proactor event loops')
@@ -1423,7 +1423,7 @@ class EventLoopTestsMixin:
         self.assertIsNone(loop._csock)
         self.assertIsNone(loop._ssock)
 
-    @unittest.skipUnless(not sys.platform.startswith('win'),
+    @unittest.skipUnless(sys.platform != 'win32',
                          "Don't support pipes for Windows")
     def test_read_pipe(self):
         proto = MyReadPipeProto(loop=self.loop)
@@ -1457,7 +1457,7 @@ class EventLoopTestsMixin:
         # extra info is available
         self.assertIsNotNone(proto.transport.get_extra_info('pipe'))
 
-    @unittest.skipUnless(not sys.platform.startswith('win'),
+    @unittest.skipUnless(sys.platform != 'win32',
                          "Don't support pipes for Windows")
     def test_unclosed_pipe_transport(self):
         # This test reproduces the issue #314 on GitHub
@@ -1491,7 +1491,7 @@ class EventLoopTestsMixin:
         read_transport._pipe = None
         write_transport._pipe = None
 
-    @unittest.skipUnless(not sys.platform.startswith('win'),
+    @unittest.skipUnless(sys.platform != 'win32',
                          "Don't support pipes for Windows")
     def test_read_pty_output(self):
         proto = MyReadPipeProto(loop=self.loop)
@@ -1526,7 +1526,7 @@ class EventLoopTestsMixin:
         # extra info is available
         self.assertIsNotNone(proto.transport.get_extra_info('pipe'))
 
-    @unittest.skipUnless(not sys.platform.startswith('win'),
+    @unittest.skipUnless(sys.platform != 'win32',
                          "Don't support pipes for Windows")
     def test_write_pipe(self):
         rpipe, wpipe = os.pipe()
@@ -1565,7 +1565,7 @@ class EventLoopTestsMixin:
         self.loop.run_until_complete(proto.done)
         self.assertEqual('CLOSED', proto.state)
 
-    @unittest.skipUnless(not sys.platform.startswith('win'),
+    @unittest.skipUnless(sys.platform != 'win32',
                          "Don't support pipes for Windows")
     def test_write_pipe_disconnect_on_close(self):
         rsock, wsock = socket.socketpair()
@@ -1588,7 +1588,7 @@ class EventLoopTestsMixin:
         self.loop.run_until_complete(proto.done)
         self.assertEqual('CLOSED', proto.state)
 
-    @unittest.skipUnless(not sys.platform.startswith('win'),
+    @unittest.skipUnless(sys.platform != 'win32',
                          "Don't support pipes for Windows")
     # select, poll and kqueue don't support character devices (PTY) on Mac OS X
     # older than 10.6 (Snow Leopard)
@@ -1632,7 +1632,7 @@ class EventLoopTestsMixin:
         self.loop.run_until_complete(proto.done)
         self.assertEqual('CLOSED', proto.state)
 
-    @unittest.skipUnless(not sys.platform.startswith('win'),
+    @unittest.skipUnless(sys.platform != 'win32',
                          "Don't support pipes for Windows")
     # select, poll and kqueue don't support character devices (PTY) on Mac OS X
     # older than 10.6 (Snow Leopard)
@@ -1840,14 +1840,14 @@ class EventLoopTestsMixin:
 class SubprocessTestsMixin:
 
     def check_terminated(self, returncode):
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             self.assertIsInstance(returncode, int)
             # expect 1 but sometimes get 0
         else:
             self.assertEqual(-signal.SIGTERM, returncode)
 
     def check_killed(self, returncode):
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             self.assertIsInstance(returncode, int)
             # expect 1 but sometimes get 0
         else:
@@ -1968,7 +1968,7 @@ class SubprocessTestsMixin:
         self.check_terminated(proto.returncode)
         transp.close()
 
-    @unittest.skipIf(sys.platform.startswith('win'), "Don't have SIGHUP")
+    @unittest.skipIf(sys.platform == 'win32', "Don't have SIGHUP")
     def test_subprocess_send_signal(self):
         # bpo-31034: Make sure that we get the default signal handler (killing
         # the process). The parent process may have decided to ignore SIGHUP,
@@ -2054,7 +2054,7 @@ class SubprocessTestsMixin:
         self.loop.run_until_complete(proto.disconnects[1])
         stdin.write(b'xxx')
         self.loop.run_until_complete(proto.got_data[2].wait())
-        if not sys.platform.startswith('win'):
+        if sys.platform != 'win32':
             self.assertEqual(b'ERR:BrokenPipeError', proto.data[2])
         else:
             # After closing the read-end of a pipe, writing to the
@@ -2331,7 +2331,7 @@ class SendfileMixin(SendfileBase):
         self.addCleanup(cleanup)
         return srv_proto, cli_proto
 
-    @unittest.skipIf(sys.platform.startswith('win'), "UDP sockets are not supported")
+    @unittest.skipIf(sys.platform == 'win32', "UDP sockets are not supported")
     def test_sendfile_not_supported(self):
         tr, pr = self.run_loop(
             self.loop.create_datagram_endpoint(
@@ -2377,7 +2377,7 @@ class SendfileMixin(SendfileBase):
         self.assertEqual(self.file.tell(), len(self.DATA))
 
     def test_sendfile_force_unsupported_native(self):
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             if isinstance(self.loop, asyncio.ProactorEventLoop):
                 self.skipTest("Fails on proactor event loop")
         srv_proto, cli_proto = self.prepare_sendfile()
@@ -2553,7 +2553,7 @@ class SendfileMixin(SendfileBase):
                 self.loop.sendfile(transport, None, fallback=False))
 
 
-if sys.platform.startswith('win'):
+if sys.platform == 'win32':
 
     class SelectEventLoopTests(EventLoopTestsMixin,
                                SendfileMixin,
@@ -3202,14 +3202,14 @@ class GetEventLoopTestsMixin:
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
 
-        if not sys.platform.startswith('win'):
+        if sys.platform != 'win32':
             watcher = asyncio.SafeChildWatcher()
             watcher.attach_loop(self.loop)
             asyncio.set_child_watcher(watcher)
 
     def tearDown(self):
         try:
-            if not sys.platform.startswith('win'):
+            if sys.platform != 'win32':
                 asyncio.set_child_watcher(None)
 
             super().tearDown()
@@ -3227,7 +3227,7 @@ class GetEventLoopTestsMixin:
             asyncio.get_running_loop = self.get_running_loop_saved
             asyncio.get_event_loop = self.get_event_loop_saved
 
-    if not sys.platform.startswith('win'):
+    if sys.platform != 'win32':
 
         def test_get_event_loop_new_process(self):
             # Issue bpo-32126: The multiprocessing module used by

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -861,7 +861,7 @@ class BaseProactorEventLoopTests(test_utils.TestCase):
         self.assertFalse(future2.cancel.called)
 
 
-@unittest.skipIf(not sys.platform.startswith('win'),
+@unittest.skipIf(sys.platform != 'win32',
                  'Proactor is supported on Windows only')
 class ProactorEventLoopUnixSockSendfileTests(test_utils.TestCase):
     DATA = b"12345abcde" * 16 * 1024  # 160 KiB

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -699,7 +699,7 @@ class StreamTests(test_utils.TestCase):
             server.stop()
             self.assertEqual(msg, b"hello world!\n")
 
-    @unittest.skipIf(sys.platform.startswith('win'), "Don't have pipes")
+    @unittest.skipIf(sys.platform == 'win32', "Don't have pipes")
     def test_read_all_from_pipe_reader(self):
         # See asyncio issue 168.  This test is derived from the example
         # subprocess_attach_read_pipe.py, but we configure the

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -10,7 +10,7 @@ from asyncio import subprocess
 from test.test_asyncio import utils as test_utils
 from test import support
 
-if not sys.platform.startswith('win'):
+if sys.platform != 'win32':
     from asyncio import unix_events
 
 # Program blocking
@@ -166,7 +166,7 @@ class SubprocessMixin:
         proc = self.loop.run_until_complete(create)
         proc.kill()
         returncode = self.loop.run_until_complete(proc.wait())
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             self.assertIsInstance(returncode, int)
             # expect 1 but sometimes get 0
         else:
@@ -178,13 +178,13 @@ class SubprocessMixin:
         proc = self.loop.run_until_complete(create)
         proc.terminate()
         returncode = self.loop.run_until_complete(proc.wait())
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             self.assertIsInstance(returncode, int)
             # expect 1 but sometimes get 0
         else:
             self.assertEqual(-signal.SIGTERM, returncode)
 
-    @unittest.skipIf(sys.platform.startswith('win'), "Don't have SIGHUP")
+    @unittest.skipIf(sys.platform == 'win32', "Don't have SIGHUP")
     def test_send_signal(self):
         # bpo-31034: Make sure that we get the default signal handler (killing
         # the process). The parent process may have decided to ignore SIGHUP,
@@ -459,14 +459,14 @@ class SubprocessMixin:
         # Unlike SafeChildWatcher, FastChildWatcher does not pop the
         # callbacks if waitpid() is called elsewhere. Let's clear them
         # manually to avoid a warning when the watcher is detached.
-        if (not sys.platform.startswith('win') and
+        if (sys.platform != 'win32' and
                 isinstance(self, SubprocessFastWatcherTests)):
             asyncio.get_child_watcher()._callbacks.clear()
 
     def test_popen_error(self):
         # Issue #24763: check that the subprocess transport is closed
         # when BaseSubprocessTransport fails
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             target = 'asyncio.windows_utils.Popen'
         else:
             target = 'subprocess.Popen'
@@ -506,7 +506,7 @@ class SubprocessMixin:
         self.loop.run_until_complete(execute())
 
 
-if not sys.platform.startswith('win'):
+if sys.platform != 'win32':
     # Unix
     class SubprocessWatcherMixin(SubprocessMixin):
 

--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -16,7 +16,7 @@ import unittest
 from unittest import mock
 from test import support
 
-if sys.platform.startswith('win'):
+if sys.platform == 'win32':
     raise unittest.SkipTest('UNIX only')
 
 

--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -4,7 +4,7 @@ import sys
 import unittest
 from unittest import mock
 
-if not sys.platform.startswith('win'):
+if sys.platform != 'win32':
     raise unittest.SkipTest('Windows only')
 
 import _overlapped

--- a/Lib/test/test_asyncio/test_windows_utils.py
+++ b/Lib/test/test_asyncio/test_windows_utils.py
@@ -4,7 +4,7 @@ import sys
 import unittest
 import warnings
 
-if not sys.platform.startswith('win'):
+if sys.platform != 'win32':
     raise unittest.SkipTest('Windows only')
 
 import _overlapped

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -152,7 +152,7 @@ class CmdLineTest(unittest.TestCase):
     # command line, but how subprocess does decode bytes to unicode. Python
     # doesn't decode the command line because Windows provides directly the
     # arguments as unicode (using wmain() instead of main()).
-    @unittest.skipIf(sys.platform.startswith('win'),
+    @unittest.skipIf(sys.platform == 'win32',
                      'Windows has a native unicode API')
     def test_undecodable_code(self):
         undecodable = b"\xff"
@@ -331,7 +331,7 @@ class CmdLineTest(unittest.TestCase):
             print(4, file=sys.stderr)"""
         rc, out, err = assert_python_ok('-c', code)
 
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             self.assertEqual(b'1\r\n2\r\n', out)
             self.assertEqual(b'3\r\n4', err)
         else:
@@ -699,7 +699,7 @@ class CmdLineTest(unittest.TestCase):
         self.assertEqual(proc.stdout.rstrip(), 'True')
         self.assertEqual(proc.returncode, 0, proc)
 
-    @unittest.skipUnless(sys.platform.startswith('win'),
+    @unittest.skipUnless(sys.platform == 'win32',
                          'bpo-32457 only applies on Windows')
     def test_argv0_normalization(self):
         args = sys.executable, '-c', 'print(0)'

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -494,7 +494,7 @@ class CmdLineTest(unittest.TestCase):
         # Windows allows creating a name with an arbitrary bytes name, but
         # Python cannot a undecodable bytes argument to a subprocess.
         if (support.TESTFN_UNDECODABLE
-        and sys.platform not in ('win32', 'win-arm', 'darwin')):
+        and sys.platform not in ('win32', 'darwin')):
             name = os.fsdecode(support.TESTFN_UNDECODABLE)
         elif support.TESTFN_NONASCII:
             name = support.TESTFN_NONASCII

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -841,7 +841,7 @@ class UTF8Test(ReadTest, unittest.TestCase):
             b"abc\xed\xa0z".decode(self.encoding, "surrogatepass")
 
 
-@unittest.skipUnless(sys.platform.startswith('win'),
+@unittest.skipUnless(sys.platform == 'win32',
                      'cp65001 is a Windows-only codec')
 class CP65001Test(ReadTest, unittest.TestCase):
     encoding = "cp65001"
@@ -3020,7 +3020,7 @@ class ExceptionChainingTest(unittest.TestCase):
 
 
 
-@unittest.skipUnless(sys.platform.startswith('win'),
+@unittest.skipUnless(sys.platform == 'win32',
                      'code pages are specific to Windows')
 class CodePageTest(unittest.TestCase):
     # CP_UTF8 is already tested by CP65001Test

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -153,7 +153,7 @@ class ProcessPoolForkMixin(ExecutorMixin):
     ctx = "fork"
 
     def get_context(self):
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             self.skipTest("require unix system")
         return super().get_context()
 
@@ -168,7 +168,7 @@ class ProcessPoolForkserverMixin(ExecutorMixin):
     ctx = "forkserver"
 
     def get_context(self):
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             self.skipTest("require unix system")
         return super().get_context()
 

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -4862,7 +4862,7 @@ class CWhitebox(unittest.TestCase):
         for attr in ('prec', 'Emin', 'Emax', 'capitals', 'clamp'):
             self.assertRaises(OverflowError, setattr, c, attr, int_max+1)
             self.assertRaises(OverflowError, setattr, c, attr, -int_max-2)
-            if not sys.platform.startswith('win'):
+            if sys.platform != 'win32':
                 self.assertRaises(ValueError, setattr, c, attr, int_max)
                 self.assertRaises(ValueError, setattr, c, attr, -int_max-1)
 
@@ -4937,7 +4937,7 @@ class CWhitebox(unittest.TestCase):
         # OverflowError, general ValueError
         self.assertRaises(OverflowError, setattr, c, '_allcr', int_max+1)
         self.assertRaises(OverflowError, setattr, c, '_allcr', -int_max-2)
-        if not sys.platform.startswith('win'):
+        if sys.platform != 'win32':
             self.assertRaises(ValueError, setattr, c, '_allcr', int_max)
             self.assertRaises(ValueError, setattr, c, '_allcr', -int_max-1)
 
@@ -4945,7 +4945,7 @@ class CWhitebox(unittest.TestCase):
         for attr in ('_flags', '_traps'):
             self.assertRaises(OverflowError, setattr, c, attr, int_max+1)
             self.assertRaises(OverflowError, setattr, c, attr, -int_max-2)
-            if not sys.platform.startswith('win'):
+            if sys.platform != 'win32':
                 self.assertRaises(TypeError, setattr, c, attr, int_max)
                 self.assertRaises(TypeError, setattr, c, attr, -int_max-1)
 

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -36,7 +36,7 @@ class EmbeddingTestsMixin:
         """Runs a test in the embedded interpreter"""
         cmd = [self.test_exe]
         cmd.extend(args)
-        if env is not None and sys.platform.startswith('win'):
+        if env is not None and sys.platform == 'win32':
             # Windows requires at least the SYSTEMROOT environment variable to
             # start Python.
             env = env.copy()
@@ -197,7 +197,7 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
         """
         env = dict(os.environ, PYTHONPATH=os.pathsep.join(sys.path))
         out, err = self.run_embedded_interpreter("pre_initialization_api", env=env)
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             expected_path = self.test_exe
         else:
             expected_path = os.path.join(os.getcwd(), "spam")

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -2,7 +2,6 @@
 
 import copy
 import os
-import platform
 import sys
 import unittest
 import pickle
@@ -285,7 +284,7 @@ class ExceptionTests(unittest.TestCase):
             self.assertEqual(w.filename, None)
             self.assertEqual(w.filename2, None)
 
-    @unittest.skipUnless(sys.platform.startswith('win'),
+    @unittest.skipUnless(sys.platform == 'win32',
                          'test specific to Windows')
     def test_windows_message(self):
         """Should fill in unknown error code in Windows error message"""

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -170,7 +170,7 @@ class FaultHandlerTests(unittest.TestCase):
             3,
             'Aborted')
 
-    @unittest.skipIf(sys.platform.startswith('win'),
+    @unittest.skipIf(sys.platform == 'win32',
                      "SIGFPE cannot be caught on Windows")
     def test_sigfpe(self):
         self.check_fatal_error("""
@@ -265,7 +265,7 @@ class FaultHandlerTests(unittest.TestCase):
                 'Segmentation fault',
                 filename=filename)
 
-    @unittest.skipIf(sys.platform.startswith("win"),
+    @unittest.skipIf(sys.platform == "win32",
                      "subprocess doesn't support pass_fds on Windows")
     @skip_segfault_on_android
     def test_enable_fd(self):
@@ -420,7 +420,7 @@ class FaultHandlerTests(unittest.TestCase):
         with temporary_filename() as filename:
             self.check_dump_traceback(filename=filename)
 
-    @unittest.skipIf(sys.platform.startswith("win"),
+    @unittest.skipIf(sys.platform == "win32",
                      "subprocess doesn't support pass_fds on Windows")
     def test_dump_traceback_fd(self):
         with tempfile.TemporaryFile('wb+') as fp:
@@ -593,7 +593,7 @@ class FaultHandlerTests(unittest.TestCase):
         with temporary_filename() as filename:
             self.check_dump_traceback_later(filename=filename)
 
-    @unittest.skipIf(sys.platform.startswith("win"),
+    @unittest.skipIf(sys.platform == "win32",
                      "subprocess doesn't support pass_fds on Windows")
     def test_dump_traceback_later_fd(self):
         with tempfile.TemporaryFile('wb+') as fp:
@@ -695,7 +695,7 @@ class FaultHandlerTests(unittest.TestCase):
         with temporary_filename() as filename:
             self.check_register(filename=filename)
 
-    @unittest.skipIf(sys.platform.startswith("win"),
+    @unittest.skipIf(sys.platform == "win32",
                      "subprocess doesn't support pass_fds on Windows")
     def test_register_fd(self):
         with tempfile.TemporaryFile('wb+') as fp:

--- a/Lib/test/test_fileio.py
+++ b/Lib/test/test_fileio.py
@@ -2,7 +2,6 @@
 
 import sys
 import os
-import platform
 import io
 import errno
 import unittest
@@ -372,7 +371,7 @@ class OtherFileTests:
             self.assertEqual(f.isatty(), False)
             f.close()
 
-            if not sys.platform.startswith("win"):
+            if sys.platform != "win32":
                 try:
                     f = self.FileIO("/dev/tty", "a")
                 except OSError:
@@ -465,7 +464,7 @@ class OtherFileTests:
     def testInvalidFd(self):
         self.assertRaises(ValueError, self.FileIO, -10)
         self.assertRaises(OSError, self.FileIO, make_bad_fd())
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             import msvcrt
             self.assertRaises(OSError, msvcrt.get_osfhandle, make_bad_fd())
 

--- a/Lib/test/test_genericpath.py
+++ b/Lib/test/test_genericpath.py
@@ -418,7 +418,7 @@ class CommonTest(GenericTest):
             self.assertIn(b"foo", self.pathmodule.abspath(b"foo"))
 
         # avoid UnicodeDecodeError on Windows
-        undecodable_path = b'' if sys.platform.startswith('win') else b'f\xf2\xf2'
+        undecodable_path = b'' if sys.platform == 'win32' else b'f\xf2\xf2'
 
         # Abspath returns bytes when the arg is bytes
         with warnings.catch_warnings():
@@ -461,7 +461,7 @@ class CommonTest(GenericTest):
         # UTF-8 name. Windows allows creating a directory with an
         # arbitrary bytes name, but fails to enter this directory
         # (when the bytes name is used).
-        and sys.platform not in ('win32', 'win-arm', 'darwin')):
+        and sys.platform not in ('win32', 'darwin')):
             name = support.TESTFN_UNDECODABLE
         elif support.TESTFN_NONASCII:
             name = support.TESTFN_NONASCII

--- a/Lib/test/test_glob.py
+++ b/Lib/test/test_glob.py
@@ -161,7 +161,7 @@ class GlobTests(unittest.TestCase):
         eq(self.glob('sym1'), [self.norm('sym1')])
         eq(self.glob('sym2'), [self.norm('sym2')])
 
-    @unittest.skipUnless(sys.platform.startswith("win"), "Win32 specific test")
+    @unittest.skipUnless(sys.platform == "win32", "Win32 specific test")
     def test_glob_magic_in_drive(self):
         eq = self.assertSequencesEqual_noorder
         eq(glob.glob('*:'), [])
@@ -186,7 +186,7 @@ class GlobTests(unittest.TestCase):
         check('[[_/*?*/_]]', '[[][[]_/[*][?][*]/_]]')
         check('/[[_/*?*/_]]/', '/[[][[]_/[*][?][*]/_]]/')
 
-    @unittest.skipUnless(sys.platform.startswith("win"), "Win32 specific test")
+    @unittest.skipUnless(sys.platform == "win32", "Win32 specific test")
     def test_escape_windows(self):
         check = self.check_escape
         check('?:?', '?:[?]')

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -386,7 +386,7 @@ class SimpleHTTPServerTestCase(BaseTestCase):
 
     @unittest.skipIf(sys.platform == 'darwin',
                      'undecodable name cannot always be decoded on macOS')
-    @unittest.skipIf(sys.platform.startswith('win'),
+    @unittest.skipIf(sys.platform == 'win32',
                      'undecodable name cannot be decoded on win32')
     @unittest.skipUnless(support.TESTFN_UNDECODABLE,
                          'need support.TESTFN_UNDECODABLE')

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -641,7 +641,7 @@ class PathsTests(unittest.TestCase):
         unload("test_trailing_slash")
 
     # Regression test for http://bugs.python.org/issue3677.
-    @unittest.skipUnless(sys.platform.startswith('win'), 'Windows-specific')
+    @unittest.skipUnless(sys.platform == 'win32', 'Windows-specific')
     def test_UNC_path(self):
         with open(os.path.join(self.path, 'test_unc_path.py'), 'w') as f:
             f.write("testdata = 'test_unc_path'")

--- a/Lib/test/test_importlib/source/test_finder.py
+++ b/Lib/test/test_importlib/source/test_finder.py
@@ -153,7 +153,7 @@ class FinderTests(abc.FinderTests):
         found = self._find(finder, 'mod', loader_only=True)
         self.assertIsNone(found)
 
-    @unittest.skipUnless(not sys.platform.startswith('win'),
+    @unittest.skipUnless(sys.platform != 'win32',
             'os.chmod() does not support the needed arguments under Windows')
     def test_no_read_directory(self):
         # Issue #16730

--- a/Lib/test/test_importlib/util.py
+++ b/Lib/test/test_importlib/util.py
@@ -92,7 +92,7 @@ def test_both(test_class, base=None, **kwargs):
 CASE_INSENSITIVE_FS = True
 # Windows is the only OS that is *always* case-insensitive
 # (OS X *can* be case-sensitive).
-if sys.platform not in ('win32', 'win-arm', 'cygwin'):
+if sys.platform not in ('win32', 'cygwin'):
     changed_name = __file__.upper()
     if changed_name == __file__:
         changed_name = __file__.lower()

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -385,7 +385,7 @@ class TestNtpath(unittest.TestCase):
             # Make sure different files are really different
             self.assertFalse(ntpath.sameopenfile(tf1.fileno(), tf2.fileno()))
             # Make sure invalid values don't cause issues on win32
-            if sys.platform.startswith("win"):
+            if sys.platform == "win32":
                 with self.assertRaises(OSError):
                     # Invalid file descriptors shouldn't display assert
                     # dialogs (#4804)
@@ -409,7 +409,7 @@ class TestNtpath(unittest.TestCase):
         with support.temp_dir() as d:
             self.assertFalse(ntpath.ismount(d))
 
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             #
             # Make sure the current folder isn't the root folder
             # (or any other volume root). The drive-relative

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -181,7 +181,7 @@ class FileTests(unittest.TestCase):
             shell=True)
         self.assertEqual(retcode, 0)
 
-    @unittest.skipUnless(sys.platform.startswith('win'),
+    @unittest.skipUnless(sys.platform == 'win32',
                          'test specific to the Windows console')
     def test_write_windows_console(self):
         # Issue #11395: the Windows console returns an error (12: not enough
@@ -382,7 +382,7 @@ class StatAttributeTests(unittest.TestCase):
             unpickled = pickle.loads(p)
             self.assertEqual(result, unpickled)
 
-    @unittest.skipUnless(sys.platform.startswith("win"), "Win32 specific tests")
+    @unittest.skipUnless(sys.platform == "win32", "Win32 specific tests")
     def test_1686475(self):
         # Verify that an open file can be stat'ed
         try:
@@ -392,7 +392,7 @@ class StatAttributeTests(unittest.TestCase):
         except OSError as e:
             self.fail("Could not stat pagefile.sys")
 
-    @unittest.skipUnless(sys.platform.startswith("win"), "Win32 specific tests")
+    @unittest.skipUnless(sys.platform == "win32", "Win32 specific tests")
     @unittest.skipUnless(hasattr(os, "pipe"), "requires os.pipe()")
     def test_15261(self):
         # Verify that stat'ing a closed fd does not cause crash
@@ -411,7 +411,7 @@ class StatAttributeTests(unittest.TestCase):
         self.assertTrue(isinstance(result.st_file_attributes, int))
         self.assertTrue(0 <= result.st_file_attributes <= 0xFFFFFFFF)
 
-    @unittest.skipUnless(sys.platform.startswith("win"),
+    @unittest.skipUnless(sys.platform == "win32",
                          "st_file_attributes is Win32 specific")
     def test_file_attributes(self):
         # test file st_file_attributes (FILE_ATTRIBUTE_DIRECTORY not set)
@@ -432,7 +432,7 @@ class StatAttributeTests(unittest.TestCase):
             result.st_file_attributes & stat.FILE_ATTRIBUTE_DIRECTORY,
             stat.FILE_ATTRIBUTE_DIRECTORY)
 
-    @unittest.skipUnless(sys.platform.startswith("win"), "Win32 specific tests")
+    @unittest.skipUnless(sys.platform == "win32", "Win32 specific tests")
     def test_access_denied(self):
         # Default to FindFirstFile WIN32_FIND_DATA when access is
         # denied. See issue 28075.
@@ -609,7 +609,7 @@ class UtimeTests(unittest.TestCase):
         self._test_utime_current(set_time)
 
     def get_file_system(self, path):
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             root = os.path.splitdrive(os.path.abspath(path))[0] + '\\'
             import ctypes
             kernel32 = ctypes.windll.kernel32
@@ -771,7 +771,7 @@ class EnvironTests(mapping_tests.BasicTestMappingProtocol):
     # On OS X < 10.6, unsetenv() doesn't return a value (bpo-13415).
     @support.requires_mac_ver(10, 6)
     def test_unset_error(self):
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             # an environment variable is limited to 32,767 characters
             key = 'x' * 50000
             self.assertRaises(ValueError, os.environ.__delitem__, key)
@@ -1575,7 +1575,7 @@ class ExecTests(unittest.TestCase):
             os.execve(args[0], args, newenv)
 
 
-@unittest.skipUnless(sys.platform.startswith("win"), "Win32 specific tests")
+@unittest.skipUnless(sys.platform == "win32", "Win32 specific tests")
 class Win32ErrorTests(unittest.TestCase):
     def setUp(self):
         try:
@@ -1748,7 +1748,7 @@ class LinkTests(unittest.TestCase):
         self.file2 = self.file1 + "2"
         self._test_link(self.file1, self.file2)
 
-@unittest.skipIf(sys.platform.startswith("win"), "Posix specific tests")
+@unittest.skipIf(sys.platform == "win32", "Posix specific tests")
 class PosixUidGidTests(unittest.TestCase):
     @unittest.skipUnless(hasattr(os, 'setuid'), 'test needs os.setuid()')
     def test_setuid(self):
@@ -1804,7 +1804,7 @@ class PosixUidGidTests(unittest.TestCase):
                 sys.executable, '-c',
                 'import os,sys;os.setregid(-1,-1);sys.exit(0)'])
 
-@unittest.skipIf(sys.platform.startswith("win"), "Posix specific tests")
+@unittest.skipIf(sys.platform == "win32", "Posix specific tests")
 class Pep383Tests(unittest.TestCase):
     def setUp(self):
         if support.TESTFN_UNENCODABLE:
@@ -1876,7 +1876,7 @@ class Pep383Tests(unittest.TestCase):
         for fn in self.unicodefn:
             os.stat(os.path.join(self.dir, fn))
 
-@unittest.skipUnless(sys.platform.startswith("win"), "Win32 specific tests")
+@unittest.skipUnless(sys.platform == "win32", "Win32 specific tests")
 class Win32KillTests(unittest.TestCase):
     def _kill(self, sig):
         # Start sys.executable as a subprocess and communicate from the
@@ -1992,7 +1992,7 @@ class Win32KillTests(unittest.TestCase):
         self._kill_with_event(signal.CTRL_BREAK_EVENT, "CTRL_BREAK_EVENT")
 
 
-@unittest.skipUnless(sys.platform.startswith("win"), "Win32 specific tests")
+@unittest.skipUnless(sys.platform == "win32", "Win32 specific tests")
 class Win32ListdirTests(unittest.TestCase):
     """Test listdir on Windows."""
 
@@ -2040,7 +2040,7 @@ class Win32ListdirTests(unittest.TestCase):
                 [os.fsencode(path) for path in self.created_paths])
 
 
-@unittest.skipUnless(sys.platform.startswith("win"), "Win32 specific tests")
+@unittest.skipUnless(sys.platform == "win32", "Win32 specific tests")
 @support.skip_unless_symlink
 class Win32SymlinkTests(unittest.TestCase):
     filelink = 'filelinktest'
@@ -2200,7 +2200,7 @@ class Win32SymlinkTests(unittest.TestCase):
                 except OSError:
                     pass
 
-@unittest.skipUnless(sys.platform.startswith("win"), "Win32 specific tests")
+@unittest.skipUnless(sys.platform == "win32", "Win32 specific tests")
 class Win32JunctionTests(unittest.TestCase):
     junction = 'junctiontest'
     junction_target = os.path.dirname(os.path.abspath(__file__))
@@ -2930,7 +2930,7 @@ class TermsizeTests(unittest.TestCase):
         try:
             size = os.get_terminal_size()
         except OSError as e:
-            if sys.platform.startswith("win") or e.errno in (errno.EINVAL, errno.ENOTTY):
+            if sys.platform == "win32" or e.errno in (errno.EINVAL, errno.ENOTTY):
                 # Under win32 a generic OSError can be thrown if the
                 # handle cannot be retrieved
                 self.skipTest("failed to query terminal size")
@@ -2956,7 +2956,7 @@ class TermsizeTests(unittest.TestCase):
         try:
             actual = os.get_terminal_size(sys.__stdin__.fileno())
         except OSError as e:
-            if sys.platform.startswith("win") or e.errno in (errno.EINVAL, errno.ENOTTY):
+            if sys.platform == "win32" or e.errno in (errno.EINVAL, errno.ENOTTY):
                 # Under win32 a generic OSError can be thrown if the
                 # handle cannot be retrieved
                 self.skipTest("failed to query terminal size")
@@ -2997,7 +2997,7 @@ class OSErrorTests(unittest.TestCase):
             (self.filenames, os.stat,),
             (self.filenames, os.unlink,),
         ]
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             funcs.extend((
                 (self.bytes_filenames, os.rename, b"dst"),
                 (self.bytes_filenames, os.replace, b"dst"),
@@ -3024,7 +3024,7 @@ class OSErrorTests(unittest.TestCase):
         if hasattr(os, "chroot"):
             funcs.append((self.filenames, os.chroot,))
         if hasattr(os, "link"):
-            if sys.platform.startswith("win"):
+            if sys.platform == "win32":
                 funcs.append((self.bytes_filenames, os.link, b"dst"))
                 funcs.append((self.unicode_filenames, os.link, "dst"))
             else:
@@ -3039,7 +3039,7 @@ class OSErrorTests(unittest.TestCase):
         if hasattr(os, "lchmod"):
             funcs.append((self.filenames, os.lchmod, 0o777))
         if hasattr(os, "readlink"):
-            if sys.platform.startswith("win"):
+            if sys.platform == "win32":
                 funcs.append((self.unicode_filenames, os.readlink,))
             else:
                 funcs.append((self.filenames, os.readlink,))

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -14,11 +14,10 @@ class PlatformTest(unittest.TestCase):
         res = platform.architecture()
 
     @support.skip_unless_symlink
-    @unittest.skipIf(platform.win32_is_iot(), "symbolic links don't work on Windows IoT Core or nanoserver")
     def test_architecture_via_symlink(self): # issue3762
         # On Windows, the EXE needs to know where pythonXY.dll and *.pyd is at
         # so we add the directory to the path and PYTHONPATH.
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             def restore_environ(old_env):
                 os.environ.clear()
                 os.environ.update(old_env)
@@ -304,7 +303,7 @@ class PlatformTest(unittest.TestCase):
             self.assertEqual(platform._parse_release_file(input), output)
 
     def test_popen(self):
-        mswindows = (sys.platform.startswith("win"))
+        mswindows = (sys.platform == "win32")
 
         if mswindows:
             command = '"{}" -c "print(\'Hello\')"'.format(sys.executable)

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -533,7 +533,7 @@ class ProgramsTestCase(BaseTestCase):
                               '--testdir=%s' % self.tmptestdir]
         if hasattr(faulthandler, 'dump_traceback_later'):
             self.regrtest_args.extend(('--timeout', '3600', '-j4'))
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             self.regrtest_args.append('-n')
 
     def check_output(self, output):
@@ -596,7 +596,7 @@ class ProgramsTestCase(BaseTestCase):
 
     @unittest.skipUnless(sysconfig.is_python_build(),
                          'test.bat script is not installed')
-    @unittest.skipUnless(sys.platform.startswith('win'), 'Windows only')
+    @unittest.skipUnless(sys.platform == 'win32', 'Windows only')
     def test_tools_buildbot_test(self):
         # Tools\buildbot\test.bat
         script = os.path.join(ROOT_DIR, 'Tools', 'buildbot', 'test.bat')
@@ -607,7 +607,7 @@ class ProgramsTestCase(BaseTestCase):
             test_args.append('+d')     # Release build, use python.exe
         self.run_batch(script, *test_args, *self.tests)
 
-    @unittest.skipUnless(sys.platform.startswith('win'), 'Windows only')
+    @unittest.skipUnless(sys.platform == 'win32', 'Windows only')
     def test_pcbuild_rt(self):
         # PCbuild\rt.bat
         script = os.path.join(ROOT_DIR, r'PCbuild\rt.bat')

--- a/Lib/test/test_selectors.py
+++ b/Lib/test/test_selectors.py
@@ -348,7 +348,7 @@ class BaseSelectorTestCase(unittest.TestCase):
 
         self.assertEqual(bufs, [MSG] * NUM_SOCKETS)
 
-    @unittest.skipIf(sys.platform.startswith('win'),
+    @unittest.skipIf(sys.platform == 'win32',
                      'select.select() cannot be used with empty fd sets')
     def test_empty_select(self):
         # Issue #23009: Make sure EpollSelector.select() works when no FD is

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1456,7 +1456,7 @@ class TestWhich(unittest.TestCase):
         base_dir = os.path.dirname(self.dir)
         with support.change_cwd(path=self.dir):
             rv = shutil.which(self.file, path=base_dir)
-            if sys.platform.startswith("win"):
+            if sys.platform == "win32":
                 # Windows: current directory implicitly on PATH
                 self.assertEqual(rv, os.path.join(os.curdir, self.file))
             else:
@@ -1484,7 +1484,7 @@ class TestWhich(unittest.TestCase):
         rv = shutil.which("foo.exe", path=self.dir)
         self.assertIsNone(rv)
 
-    @unittest.skipUnless(sys.platform.startswith("win"),
+    @unittest.skipUnless(sys.platform == "win32",
                          "pathext check is Windows-only")
     def test_pathext_checking(self):
         # Ask for the file without the ".exe" extension, then ensure that

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -29,10 +29,10 @@ class GenericTests(unittest.TestCase):
                 self.assertIsInstance(sig, signal.Signals)
             elif name.startswith('CTRL_'):
                 self.assertIsInstance(sig, signal.Signals)
-                self.assertEqual(sys.platform[:3], "win")
+                self.assertEqual(sys.platform, "win32")
 
 
-@unittest.skipIf(sys.platform.startswith("win"), "Not valid on Windows")
+@unittest.skipIf(sys.platform == "win32", "Not valid on Windows")
 class PosixTests(unittest.TestCase):
     def trivial_signal_handler(self, *args):
         pass
@@ -62,7 +62,7 @@ class PosixTests(unittest.TestCase):
         assert_python_ok(script)
 
 
-@unittest.skipUnless(sys.platform.startswith("win"), "Windows specific")
+@unittest.skipUnless(sys.platform == "win32", "Windows specific")
 class WindowsSignalTests(unittest.TestCase):
     def test_issue9324(self):
         # Updated for issue #10003, adding SIGBREAK
@@ -144,7 +144,7 @@ class WakeupFDTests(unittest.TestCase):
 
     # On Windows, files are always blocking and Windows does not provide a
     # function to test if a socket is in non-blocking mode.
-    @unittest.skipIf(sys.platform.startswith("win"), "tests specific to POSIX")
+    @unittest.skipIf(sys.platform == "win32", "tests specific to POSIX")
     def test_set_wakeup_fd_blocking(self):
         rfd, wfd = os.pipe()
         self.addCleanup(os.close, rfd)
@@ -163,7 +163,7 @@ class WakeupFDTests(unittest.TestCase):
         signal.set_wakeup_fd(-1)
 
 
-@unittest.skipIf(sys.platform.startswith("win"), "Not valid on Windows")
+@unittest.skipIf(sys.platform == "win32", "Not valid on Windows")
 class WakeupSignalTests(unittest.TestCase):
     @unittest.skipIf(_testcapi is None, 'need _testcapi')
     def check_wakeup(self, test_body, *signals, ordered=True):
@@ -456,7 +456,7 @@ class WakeupSocketSignalTests(unittest.TestCase):
         read, write = socket.socketpair()
 
         # Fill the socketpair buffer
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             # bpo-34130: On Windows, sometimes non-blocking send fails to fill
             # the full socketpair buffer, so use a timeout of 50 ms instead.
             write.settimeout(0.050)
@@ -538,7 +538,7 @@ class WakeupSocketSignalTests(unittest.TestCase):
         assert_python_ok('-c', code)
 
 
-@unittest.skipIf(sys.platform.startswith("win"), "Not valid on Windows")
+@unittest.skipIf(sys.platform == "win32", "Not valid on Windows")
 class SiginterruptTest(unittest.TestCase):
 
     def readpipe_interrupted(self, interrupt):
@@ -623,7 +623,7 @@ class SiginterruptTest(unittest.TestCase):
         self.assertFalse(interrupted)
 
 
-@unittest.skipIf(sys.platform.startswith("win"), "Not valid on Windows")
+@unittest.skipIf(sys.platform == "win32", "Not valid on Windows")
 class ItimerTest(unittest.TestCase):
     def setUp(self):
         self.hndl_called = False

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -415,7 +415,7 @@ class ImportSideEffectTests(unittest.TestCase):
         self.assertTrue(hasattr(builtins, "help"))
 
     def test_aliasing_mbcs(self):
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             import locale
             if locale.getdefaultlocale()[1].startswith('cp'):
                 for value in encodings.aliases.aliases.values():
@@ -504,7 +504,7 @@ class StartupImportTests(unittest.TestCase):
         self.assertTrue(r, "'__interactivehook__' not added by enablerlcompleter()")
 
 
-@unittest.skipUnless(sys.platform.startswith('win'), "only supported on Windows")
+@unittest.skipUnless(sys.platform == 'win32', "only supported on Windows")
 class _pthFileTests(unittest.TestCase):
 
     def _create_underpth_exe(self, lines):

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1126,7 +1126,7 @@ class GeneralModuleTests(unittest.TestCase):
         except ImportError:
             self.skipTest('could not import needed symbols from socket')
 
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             try:
                 inet_pton(AF_INET6, '::')
             except OSError as e:
@@ -1216,7 +1216,7 @@ class GeneralModuleTests(unittest.TestCase):
         except ImportError:
             self.skipTest('could not import needed symbols from socket')
 
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             try:
                 inet_ntop(AF_INET6, b'\x00' * 16)
             except OSError as e:
@@ -1622,7 +1622,7 @@ class GeneralModuleTests(unittest.TestCase):
 
     @unittest.skipUnless(support.IPV6_ENABLED, 'IPv6 required for this test.')
     @unittest.skipUnless(
-        sys.platform.startswith('win'),
+        sys.platform == 'win32',
         'Numeric scope id does not work or undocumented')
     def test_getaddrinfo_ipv6_scopeid_numeric(self):
         # Also works on Linux and Mac OS X, but is not documented (?)
@@ -1650,7 +1650,7 @@ class GeneralModuleTests(unittest.TestCase):
 
     @unittest.skipUnless(support.IPV6_ENABLED, 'IPv6 required for this test.')
     @unittest.skipUnless(
-        sys.platform.startswith('win'),
+        sys.platform == 'win32',
         'Numeric scope id does not work or undocumented')
     def test_getnameinfo_ipv6_scopeid_numeric(self):
         # Also works on Linux (undocumented), but does not work on Mac OS X

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -784,7 +784,7 @@ class BasicSocketTests(unittest.TestCase):
             self.assertEqual(paths.cafile, CERTFILE)
             self.assertEqual(paths.capath, CAPATH)
 
-    @unittest.skipUnless(sys.platform.startswith("win"), "Windows specific")
+    @unittest.skipUnless(sys.platform == "win32", "Windows specific")
     def test_enum_certificates(self):
         self.assertTrue(ssl.enum_certificates("CA"))
         self.assertTrue(ssl.enum_certificates("ROOT"))
@@ -809,7 +809,7 @@ class BasicSocketTests(unittest.TestCase):
         serverAuth = "1.3.6.1.5.5.7.3.1"
         self.assertIn(serverAuth, trust_oids)
 
-    @unittest.skipUnless(sys.platform.startswith("win"), "Windows specific")
+    @unittest.skipUnless(sys.platform == "win32", "Windows specific")
     def test_enum_crls(self):
         self.assertTrue(ssl.enum_crls("CA"))
         self.assertRaises(TypeError, ssl.enum_crls)
@@ -1452,7 +1452,7 @@ class ContextTests(unittest.TestCase):
         self.assertRaises(TypeError, ctx.load_default_certs, None)
         self.assertRaises(TypeError, ctx.load_default_certs, 'SERVER_AUTH')
 
-    @unittest.skipIf(sys.platform.startswith("win"), "not-Windows specific")
+    @unittest.skipIf(sys.platform == "win32", "not-Windows specific")
     @unittest.skipIf(IS_LIBRESSL, "LibreSSL doesn't support env vars")
     def test_load_default_certs_env(self):
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
@@ -1462,7 +1462,7 @@ class ContextTests(unittest.TestCase):
             ctx.load_default_certs()
             self.assertEqual(ctx.cert_store_stats(), {"crl": 0, "x509": 1, "x509_ca": 0})
 
-    @unittest.skipUnless(sys.platform.startswith("win"), "Windows specific")
+    @unittest.skipUnless(sys.platform == "win32", "Windows specific")
     @unittest.skipIf(hasattr(sys, "gettotalrefcount"), "Debug build does not share environment between CRTs")
     def test_load_default_certs_env_windows(self):
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -209,7 +209,7 @@ class TestFilemode:
             self.assertTrue(callable(func))
             self.assertEqual(func(0), 0)
 
-    @unittest.skipUnless(sys.platform.startswith("win"),
+    @unittest.skipUnless(sys.platform == "win32",
                          "FILE_ATTRIBUTE_* constants are Win32 specific")
     def test_file_attribute_constants(self):
         for key, value in sorted(self.file_attributes.items()):

--- a/Lib/test/test_strftime.py
+++ b/Lib/test/test_strftime.py
@@ -187,7 +187,7 @@ class Y1900Tests(unittest.TestCase):
     def test_y_before_1900(self):
         # Issue #13674, #19634
         t = (1899, 1, 1, 0, 0, 0, 0, 0, 0)
-        if (sys.platform.startswith("win")
+        if (sys.platform == "win32"
         or sys.platform.startswith(("aix", "sunos", "solaris"))):
             with self.assertRaises(ValueError):
                 time.strftime("%y", t)

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -35,7 +35,7 @@ except ImportError:
 if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
-mswindows = (sys.platform.startswith("win"))
+mswindows = (sys.platform == "win32")
 
 #
 # Depends on the following external programs: Python
@@ -632,7 +632,7 @@ class ProcessTestCase(BaseTestCase):
 
     # Windows requires at least the SYSTEMROOT environment variable to start
     # Python
-    @unittest.skipIf(sys.platform.startswith('win'),
+    @unittest.skipIf(sys.platform == 'win32',
                      'cannot test an empty env on Windows')
     @unittest.skipIf(sysconfig.get_config_var('Py_ENABLE_SHARED') == 1,
                      'The Python shared library cannot be loaded '

--- a/Lib/test/test_sysconfig.py
+++ b/Lib/test/test_sysconfig.py
@@ -235,7 +235,7 @@ class TestSysConfig(unittest.TestCase):
     def test_symlink(self):
         # On Windows, the EXE needs to know where pythonXY.dll is at so we have
         # to add the directory to the path.
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             os.environ["PATH"] = "{};{}".format(
                 os.path.dirname(sys.executable), os.environ["PATH"])
 
@@ -281,7 +281,7 @@ class TestSysConfig(unittest.TestCase):
             _main()
         self.assertTrue(len(output.getvalue().split('\n')) > 0)
 
-    @unittest.skipIf(sys.platform.startswith("win"), "Does not apply to Windows")
+    @unittest.skipIf(sys.platform == "win32", "Does not apply to Windows")
     def test_ldshared_value(self):
         ldflags = sysconfig.get_config_var('LDFLAGS')
         ldshared = sysconfig.get_config_var('LDSHARED')

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -565,7 +565,7 @@ class MiscReadTestBase(CommonReadTest):
             tar.extractall(DIR, directories)
             for tarinfo in directories:
                 path = os.path.join(DIR, tarinfo.name)
-                if not sys.platform.startswith("win"):
+                if sys.platform != "win32":
                     # Win32 has no support for fine grained permissions.
                     self.assertEqual(tarinfo.mode & 0o777,
                                      os.stat(path).st_mode & 0o777)
@@ -594,7 +594,7 @@ class MiscReadTestBase(CommonReadTest):
                 tar.extract(tarinfo, path=DIR)
                 extracted = os.path.join(DIR, dirtype)
                 self.assertEqual(os.path.getmtime(extracted), tarinfo.mtime)
-                if not sys.platform.startswith("win"):
+                if sys.platform != "win32":
                     self.assertEqual(os.stat(extracted).st_mode & 0o777, 0o755)
         finally:
             support.rmtree(DIR)
@@ -1336,7 +1336,7 @@ class WriteTest(WriteTestBase, unittest.TestCase):
         self._test_pathname("foo" + os.sep + os.sep, "foo", dir=True)
 
     def test_abs_pathnames(self):
-        if sys.platform.startswith("win"):
+        if sys.platform == "win32":
             self._test_pathname("C:\\foo", "foo")
         else:
             self._test_pathname("/foo", "foo")
@@ -1406,7 +1406,7 @@ class StreamWriteTest(WriteTestBase, unittest.TestCase):
         self.assertEqual(data.count(b"\0"), tarfile.RECORDSIZE,
                         "incorrect zero padding")
 
-    @unittest.skipUnless(not sys.platform.startswith("win") and hasattr(os, "umask"),
+    @unittest.skipUnless(sys.platform != "win32" and hasattr(os, "umask"),
                          "Missing umask implementation")
     def test_file_mode(self):
         # Test for issue #8464: Create files with correct

--- a/Lib/test/test_tcl.py
+++ b/Lib/test/test_tcl.py
@@ -226,7 +226,7 @@ class TclTest(unittest.TestCase):
         tcl = self.interp
         self.assertRaises(TclError,tcl.eval,'package require DNE')
 
-    @unittest.skipUnless(sys.platform.startswith('win'), 'Requires Windows')
+    @unittest.skipUnless(sys.platform == 'win32', 'Requires Windows')
     def testLoadWithUNC(self):
         # Build a UNC path from the regular path.
         # Something like

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -440,7 +440,7 @@ class TestMkstempInner(TestBadTempdir, BaseTestCase):
         file = self.do_create()
         mode = stat.S_IMODE(os.stat(file.name).st_mode)
         expected = 0o600
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             # There's no distinction among 'user', 'group' and 'world';
             # replicate the 'user' bits.
             user = expected >> 6
@@ -474,7 +474,7 @@ class TestMkstempInner(TestBadTempdir, BaseTestCase):
         # On Windows a spawn* /path/ with embedded spaces shouldn't be quoted,
         # but an arg with embedded spaces should be decorated with double
         # quotes on each end
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             decorated = '"%s"' % sys.executable
             tester = '"%s"' % tester
         else:
@@ -747,7 +747,7 @@ class TestMkdtemp(TestBadTempdir, BaseTestCase):
             mode = stat.S_IMODE(os.stat(dir).st_mode)
             mode &= 0o777 # Mask off sticky bits inherited from /tmp
             expected = 0o700
-            if sys.platform.startswith('win'):
+            if sys.platform == 'win32':
                 # There's no distinction among 'user', 'group' and 'world';
                 # replicate the 'user' bits.
                 user = expected >> 6

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -987,7 +987,7 @@ class TestCPyTime(CPyTimeTestCase, unittest.TestCase):
             us = us_converter(ns)
             return divmod(us, SEC_TO_US)
 
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             from _testcapi import LONG_MIN, LONG_MAX
 
             # On Windows, timeval.tv_sec type is a C long

--- a/Lib/test/test_tools/test_sundry.py
+++ b/Lib/test/test_tools/test_sundry.py
@@ -45,7 +45,7 @@ class TestSundryScripts(unittest.TestCase):
             # Unload all modules loaded in this test
             support.modules_cleanup(*old_modules)
 
-    @unittest.skipIf(not sys.platform.startswith("win"), "Windows-only test")
+    @unittest.skipIf(sys.platform != "win32", "Windows-only test")
     def test_sundry_windows(self):
         for name in self.windows_only:
             import_tool(name)

--- a/Lib/test/test_unicode_file_functions.py
+++ b/Lib/test/test_unicode_file_functions.py
@@ -103,7 +103,7 @@ class UnicodeFileTests(unittest.TestCase):
             self._apply_failure(os.remove, name)
             self._apply_failure(os.listdir, name)
 
-    if sys.platform.startswith('win'):
+    if sys.platform == 'win32':
         # Windows is lunatic. Issue #13366.
         _listdir_failure = NotADirectoryError, FileNotFoundError
     else:

--- a/Lib/test/test_urllib.py
+++ b/Lib/test/test_urllib.py
@@ -1367,7 +1367,7 @@ class Pathname_Tests(unittest.TestCase):
                          "url2pathname() failed; %s != %s" %
                          (expect, result))
 
-    @unittest.skipUnless(sys.platform.startswith('win'),
+    @unittest.skipUnless(sys.platform == 'win32',
                          'test specific to the urllib.url2path function.')
     def test_ntpath(self):
         given = ('/C:/', '///C:/', '/C|//')

--- a/Lib/test/test_utf8_mode.py
+++ b/Lib/test/test_utf8_mode.py
@@ -11,7 +11,7 @@ from test import support
 from test.support.script_helper import assert_python_ok, assert_python_failure
 
 
-MS_WINDOWS = (sys.platform.startswith('win'))
+MS_WINDOWS = (sys.platform == 'win32')
 
 
 class UTF8ModeTests(unittest.TestCase):

--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -139,7 +139,7 @@ class BasicTest(BaseTest):
             out, err = p.communicate()
             self.assertEqual(out.strip(), expected.encode())
 
-    if sys.platform.startswith('win'):
+    if sys.platform == 'win32':
         ENV_SUBDIRS = (
             ('Scripts',),
             ('Include',),

--- a/Lib/test/test_winconsoleio.py
+++ b/Lib/test/test_winconsoleio.py
@@ -8,7 +8,7 @@ import tempfile
 import unittest
 from test import support
 
-if not sys.platform.startswith('win'):
+if sys.platform != 'win32':
     raise unittest.SkipTest("test only relevant on win32")
 
 from _testconsole import write_input

--- a/Lib/test/test_zipapp.py
+++ b/Lib/test/test_zipapp.py
@@ -299,7 +299,7 @@ class ZipAppTest(unittest.TestCase):
             self.assertEqual(set(z.namelist()), {'__main__.py'})
 
     # (Unix only) tests that archives with shebang lines are made executable
-    @unittest.skipIf(sys.platform.startswith('win'),
+    @unittest.skipIf(sys.platform == 'win32',
                      'Windows does not support an executable bit')
     def test_shebang_is_executable(self):
         # Test that an archive with a shebang line is made executable.
@@ -310,7 +310,7 @@ class ZipAppTest(unittest.TestCase):
         zipapp.create_archive(str(source), str(target), interpreter='python')
         self.assertTrue(target.stat().st_mode & stat.S_IEXEC)
 
-    @unittest.skipIf(sys.platform.startswith('win'),
+    @unittest.skipIf(sys.platform == 'win32',
                      'Windows does not support an executable bit')
     def test_no_shebang_is_not_executable(self):
         # Test that an archive with no shebang line is not made executable.

--- a/Lib/unittest/test/test_break.py
+++ b/Lib/unittest/test/test_break.py
@@ -9,7 +9,7 @@ import unittest
 
 
 @unittest.skipUnless(hasattr(os, 'kill'), "Test requires os.kill")
-@unittest.skipIf(sys.platform.startswith("win"), "Test cannot run on Windows")
+@unittest.skipIf(sys.platform =="win32", "Test cannot run on Windows")
 class TestBreak(unittest.TestCase):
     int_handler = None
 
@@ -261,17 +261,17 @@ class TestBreak(unittest.TestCase):
         self.assertNotEqual(signal.getsignal(signal.SIGINT), default_handler)
 
 @unittest.skipUnless(hasattr(os, 'kill'), "Test requires os.kill")
-@unittest.skipIf(sys.platform.startswith("win"), "Test cannot run on Windows")
+@unittest.skipIf(sys.platform =="win32", "Test cannot run on Windows")
 class TestBreakDefaultIntHandler(TestBreak):
     int_handler = signal.default_int_handler
 
 @unittest.skipUnless(hasattr(os, 'kill'), "Test requires os.kill")
-@unittest.skipIf(sys.platform.startswith("win"), "Test cannot run on Windows")
+@unittest.skipIf(sys.platform =="win32", "Test cannot run on Windows")
 class TestBreakSignalIgnored(TestBreak):
     int_handler = signal.SIG_IGN
 
 @unittest.skipUnless(hasattr(os, 'kill'), "Test requires os.kill")
-@unittest.skipIf(sys.platform.startswith("win"), "Test cannot run on Windows")
+@unittest.skipIf(sys.platform =="win32", "Test cannot run on Windows")
 class TestBreakSignalDefault(TestBreak):
     int_handler = signal.SIG_DFL
 

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -675,7 +675,7 @@ def getnode(*, getters=None):
     if _node is not None:
         return _node
 
-    if sys.platform.startswith('win'):
+    if sys.platform == 'win32':
         getters = _NODE_GETTERS_WIN32
     else:
         getters = _NODE_GETTERS_UNIX

--- a/Lib/venv/__init__.py
+++ b/Lib/venv/__init__.py
@@ -113,7 +113,7 @@ class EnvBuilder:
         context.executable = executable
         context.python_dir = dirname
         context.python_exe = exename
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             binname = 'Scripts'
             incpath = 'Include'
             libpath = os.path.join(env_dir, 'Lib', 'site-packages')

--- a/Lib/wsgiref/handlers.py
+++ b/Lib/wsgiref/handlers.py
@@ -49,7 +49,7 @@ def read_environ():
 
             # On win32, the os.environ is natively Unicode. Different servers
             # decode the request bytes using different encodings.
-            if sys.platform.startswith('win'):
+            if sys.platform == 'win32':
                 software = os.environ.get('SERVER_SOFTWARE', '').lower()
 
                 # On IIS, the HTTP request will be decoded as UTF-8 as long

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -338,7 +338,7 @@ class ZipInfo (object):
         self._compresslevel = None      # Level for the compressor
         self.comment = b""              # Comment for each file
         self.extra = b""                # ZIP extra data
-        if sys.platform.startswith('win'):
+        if sys.platform == 'win32':
             self.create_system = 0          # System which created ZIP archive
         else:
             # Assume everything else is unix-y

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -312,11 +312,7 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
    should define this. */
 #       define HAVE_LARGEFILE_SUPPORT
 #elif defined(MS_WIN32)
-#ifdef _M_ARM
-#       define PLATFORM "win-arm"
-#else // _M_ARM
 #       define PLATFORM "win32"
-#endif // _M_ARM
 #       define HAVE_LARGEFILE_SUPPORT
 #       define SIZEOF_VOID_P 4
 #       define SIZEOF_OFF_T 4

--- a/PCbuild/build.bat
+++ b/PCbuild/build.bat
@@ -37,7 +37,6 @@ echo.Available flags to avoid building certain modules.
 echo.These flags have no effect if '-e' is not given:
 echo.  --no-ssl      Do not attempt to build _ssl
 echo.  --no-tkinter  Do not attempt to build Tkinter
-echo.  --no-vs       Do not attempt to build _distutils_findvs
 echo.
 echo.Available arguments:
 echo.  -c Release ^| Debug ^| PGInstrument ^| PGUpdate
@@ -84,12 +83,10 @@ if "%~1"=="-e" (set IncludeExternals=true) & shift & goto CheckOpts
 if "%~1"=="-E" (set IncludeExternals=false) & shift & goto CheckOpts
 if "%~1"=="--no-ssl" (set IncludeSSL=false) & shift & goto CheckOpts
 if "%~1"=="--no-tkinter" (set IncludeTkinter=false) & shift & goto CheckOpts
-if "%~1"=="--no-vs" (set IncludeDistUtils_FindVs=false) & shift & goto CheckOpts
 
 if "%IncludeExternals%"=="" set IncludeExternals=true
 if "%IncludeSSL%"=="" set IncludeSSL=true
 if "%IncludeTkinter%"=="" set IncludeTkinter=true
-if "%IncludeDistUtils_FindVs%"=="" set IncludeDistUtils_FindVs=true
 
 if "%IncludeExternals%"=="true" call "%dir%get_externals.bat"
 
@@ -143,7 +140,6 @@ echo on
  /p:Configuration=%conf% /p:Platform=%platf%^
  /p:IncludeExternals=%IncludeExternals%^
  /p:IncludeSSL=%IncludeSSL% /p:IncludeTkinter=%IncludeTkinter%^
- /p:IncludeDistUtils_FindVs=%IncludeDistUtils_FindVs%^
  /p:UseTestMarker=%UseTestMarker% %GITProperty%^
  %1 %2 %3 %4 %5 %6 %7 %8 %9
 

--- a/PCbuild/pcbuild.proj
+++ b/PCbuild/pcbuild.proj
@@ -49,15 +49,13 @@
     <!-- pyshellext.dll -->
     <Projects Include="pyshellext.vcxproj" />
     <!-- Extension modules -->
-    <ExtensionModules Include="_asyncio;_contextvars;_ctypes;_elementtree;_msi;_multiprocessing;_overlapped;pyexpat;_queue;select;unicodedata;winsound" />
-    <ExtensionModules Condition="$(Platform) != 'ARM'" Include="_decimal" />
+    <ExtensionModules Include="_asyncio;_contextvars;_ctypes;_decimal;_distutils_findvs;_elementtree;_msi;_multiprocessing;_overlapped;pyexpat;_queue;select;unicodedata;winsound" />
     <!-- Extension modules that require external sources -->
     <ExternalModules Include="_bz2;_lzma;_sqlite3" />
     <!-- _ssl will build _socket as well, which may cause conflicts in parallel builds -->
     <ExtensionModules Include="_socket" Condition="!$(IncludeSSL) or !$(IncludeExternals)" />
     <ExternalModules Include="_ssl;_hashlib" Condition="$(IncludeSSL)" />
     <ExternalModules Include="_tkinter" Condition="$(IncludeTkinter)" />
-    <ExtensionModules Include="_distutils_findvs" Condition="$(IncludeDistUtils_FindVs)" />
     <ExtensionModules Include="@(ExternalModules->'%(Identity)')" Condition="$(IncludeExternals)" />
     <Projects Include="@(ExtensionModules->'%(Identity).vcxproj')" Condition="$(IncludeExtensions)" />
     <!-- Test modules -->

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -185,7 +185,7 @@
 
     <!-- The version and platform tag to include in .pyd filenames -->
     <PydTag Condition="$(ArchName) == 'win32'">.cp$(MajorVersionNumber)$(MinorVersionNumber)-win32</PydTag>
-    <PydTag Condition="$(ArchName) == 'arm32'">.cp$(MajorVersionNumber)$(MinorVersionNumber)-win_arm32</PydTag>
+    <PydTag Condition="$(ArchName) == 'arm32'">.cp$(MajorVersionNumber)$(MinorVersionNumber)-win_arm</PydTag>
     <PydTag Condition="$(ArchName) == 'amd64'">.cp$(MajorVersionNumber)$(MinorVersionNumber)-win_amd64</PydTag>
     
     <!-- The version number for sys.winver -->

--- a/Tools/scripts/run_tests.py
+++ b/Tools/scripts/run_tests.py
@@ -34,7 +34,7 @@ def main(regrtest_args):
                  '-r',            # Randomize test order
                  '-w',            # Re-run failed tests in verbose mode
                  ])
-    if sys.platform.startswith('win'):
+    if sys.platform == 'win32':
         args.append('-n')         # Silence alerts under Windows
     if not any(is_multiprocess_flag(arg) for arg in regrtest_args):
         args.extend(['-j', '0'])  # Use all CPU cores
@@ -42,7 +42,7 @@ def main(regrtest_args):
         args.extend(['-u', 'all,-largefile,-audio,-gui'])
     args.extend(regrtest_args)
     print(' '.join(args))
-    if sys.platform.startswith('win'):
+    if sys.platform == 'win32':
         from subprocess import call
         sys.exit(call(args))
     else:

--- a/Tools/winiot/sync_win_iot.py
+++ b/Tools/winiot/sync_win_iot.py
@@ -56,6 +56,8 @@ EXCLUDED_FILES = {
 INCLUDED_FILES = {
     'libcrypto-1_1',
     'libssl-1_1',
+    'libcrypto-1_1-x64',
+    'libssl-1_1-x64',
 }
 
 def is_debug(p):

--- a/setup.py
+++ b/setup.py
@@ -1199,7 +1199,7 @@ class PyBuildExt(build_ext):
                 '_sqlite/util.c', ]
 
             sqlite_defines = []
-            if not host_platform.startswith("win"):
+            if host_platform != "win32":
                 sqlite_defines.append(('MODULE_NAME', '"sqlite3"'))
             else:
                 sqlite_defines.append(('MODULE_NAME', '\\"sqlite3\\"'))
@@ -1322,7 +1322,7 @@ class PyBuildExt(build_ext):
             missing.append('_gdbm')
 
         # Unix-only modules
-        if not host_platform.startswith('win'):
+        if host_platform != 'win32':
             # Steen Lumholt's termios module
             exts.append( Extension('termios', ['termios.c']) )
             # Jeremy Hylton's rlimit interface
@@ -1561,7 +1561,7 @@ class PyBuildExt(build_ext):
         self.detect_ctypes(inc_dirs, lib_dirs)
 
         # Richard Oudkerk's multiprocessing module
-        if host_platform.startswith('win'): # Windows
+        if host_platform == 'win32':        # Windows
             macros = dict()
             libraries = ['ws2_32']
 
@@ -1585,7 +1585,7 @@ class PyBuildExt(build_ext):
             macros = dict()
             libraries = ['rt']
 
-        if host_platform.startswith('win'):
+        if host_platform == 'win32':
             multiprocessing_srcs = [ '_multiprocessing/multiprocessing.c',
                                      '_multiprocessing/semaphore.c',
                                    ]
@@ -2182,7 +2182,7 @@ class PyBuildExt(build_ext):
         return ssl_ext, hashlib_ext
 
     def _detect_nis(self, inc_dirs, lib_dirs):
-        if host_platform in {'win32', 'win-arm', 'cygwin', 'qnx6'}:
+        if host_platform in {'win32', 'cygwin', 'qnx6'}:
             return None
 
         libs = []


### PR DESCRIPTION
sys.platform should remain 'win32'
'platform tag' in directories and filesnames should be win-arm or win_arm

This applies to the platform tag for pip files .tar.gz/.whl like {distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.whl for example.  
See [PEP 427](https://www.python.org/dev/peps/pep-0427/#file-name-convention)
