### PR TITLE
Use cross-platform build environment variables

### DIFF
--- a/Lib/distutils/command/bdist.py
+++ b/Lib/distutils/command/bdist.py
@@ -6,7 +6,7 @@ distribution)."""
 import os
 from distutils.core import Command
 from distutils.errors import *
-from distutils.util import get_platform
+from distutils.util import get_target_platform
 
 
 def show_formats():
@@ -29,7 +29,7 @@ class bdist(Command):
                      "temporary directory for creating built distributions"),
                     ('plat-name=', 'p',
                      "platform name to embed in generated filenames "
-                     "(default: %s)" % get_platform()),
+                     "(default: %s)" % get_target_platform()),
                     ('formats=', None,
                      "formats for distribution (comma-separated list)"),
                     ('dist-dir=', 'd',
@@ -91,7 +91,7 @@ class bdist(Command):
         # have to finalize 'plat_name' before 'bdist_base'
         if self.plat_name is None:
             if self.skip_build:
-                self.plat_name = get_platform()
+                self.plat_name = get_target_platform()
             else:
                 self.plat_name = self.get_finalized_command('build').plat_name
 

--- a/Lib/distutils/command/bdist_dumb.py
+++ b/Lib/distutils/command/bdist_dumb.py
@@ -6,7 +6,7 @@ $exec_prefix)."""
 
 import os
 from distutils.core import Command
-from distutils.util import get_platform
+from distutils.util import get_target_platform
 from distutils.dir_util import remove_tree, ensure_relative
 from distutils.errors import *
 from distutils.sysconfig import get_python_version
@@ -20,7 +20,7 @@ class bdist_dumb(Command):
                      "temporary directory for creating the distribution"),
                     ('plat-name=', 'p',
                      "platform name to embed in generated filenames "
-                     "(default: %s)" % get_platform()),
+                     "(default: %s)" % get_target_platform()),
                     ('format=', 'f',
                      "archive format to create (tar, gztar, bztar, xztar, "
                      "ztar, zip)"),

--- a/Lib/distutils/command/bdist_msi.py
+++ b/Lib/distutils/command/bdist_msi.py
@@ -12,7 +12,7 @@ from distutils.dir_util import remove_tree
 from distutils.sysconfig import get_python_version
 from distutils.version import StrictVersion
 from distutils.errors import DistutilsOptionError
-from distutils.util import get_platform
+from distutils.util import get_target_platform
 from distutils import log
 import msilib
 from msilib import schema, sequence, text
@@ -88,7 +88,7 @@ class bdist_msi(Command):
                      "temporary directory for creating the distribution"),
                     ('plat-name=', 'p',
                      "platform name to embed in generated filenames "
-                     "(default: %s)" % get_platform()),
+                     "(default: %s)" % get_target_platform()),
                     ('keep-temp', 'k',
                      "keep the pseudo-installation tree around after " +
                      "creating the distribution archive"),

--- a/Lib/distutils/command/bdist_wininst.py
+++ b/Lib/distutils/command/bdist_wininst.py
@@ -5,7 +5,7 @@ exe-program."""
 
 import sys, os
 from distutils.core import Command
-from distutils.util import get_platform
+from distutils.util import get_target_platform
 from distutils.dir_util import create_tree, remove_tree
 from distutils.errors import *
 from distutils.sysconfig import get_python_version
@@ -19,7 +19,7 @@ class bdist_wininst(Command):
                      "temporary directory for creating the distribution"),
                     ('plat-name=', 'p',
                      "platform name to embed in generated filenames "
-                     "(default: %s)" % get_platform()),
+                     "(default: %s)" % get_target_platform()),
                     ('keep-temp', 'k',
                      "keep the pseudo-installation tree around after " +
                      "creating the distribution archive"),

--- a/Lib/distutils/command/build.py
+++ b/Lib/distutils/command/build.py
@@ -5,7 +5,7 @@ Implements the Distutils 'build' command."""
 import sys, os
 from distutils.core import Command
 from distutils.errors import DistutilsOptionError
-from distutils.util import get_platform
+from distutils.util import get_target_platform
 
 
 def show_compilers():
@@ -33,7 +33,7 @@ class build(Command):
          "temporary build directory"),
         ('plat-name=', 'p',
          "platform name to build for, if supported "
-         "(default: %s)" % get_platform()),
+         "(default: %s)" % get_target_platform()),
         ('compiler=', 'c',
          "specify the compiler type"),
         ('parallel=', 'j',
@@ -71,7 +71,7 @@ class build(Command):
 
     def finalize_options(self):
         if self.plat_name is None:
-            self.plat_name = get_platform()
+            self.plat_name = get_target_platform()
         else:
             # plat-name only supported for windows (other platforms are
             # supported via ./configure flags, if at all).  Avoid misleading

--- a/Lib/distutils/command/build_ext.py
+++ b/Lib/distutils/command/build_ext.py
@@ -679,14 +679,9 @@ class build_ext(Command):
         from distutils.sysconfig import get_config_var
         ext_path = ext_name.split('.')
 
-        # TODO: make this less hard-coded
         if os.name == 'nt' and self.plat_name != get_platform():
-            if self.plat_name == 'win-arm':
-                ext_suffix = '.cp37-win_arm.pyd'
-            elif self.plat_name == 'win-amd64':
-                ext_suffix = '.cp37-win_amd64.pyd'
-            elif self.plat_name == 'win32':
-                ext_suffix = '.cp37-win32.pyd'
+            plat_tag = self.plat_name.replace('-', '_')
+            ext_suffix = '.cp{0.major}{0.minor}-{1}.pyd'.format(sys.version_info, plat_tag)
         else:
             ext_suffix = get_config_var('EXT_SUFFIX')
 

--- a/Lib/distutils/command/build_ext.py
+++ b/Lib/distutils/command/build_ext.py
@@ -678,7 +678,17 @@ class build_ext(Command):
         """
         from distutils.sysconfig import get_config_var
         ext_path = ext_name.split('.')
-        ext_suffix = get_config_var('EXT_SUFFIX')
+        
+        if os.name == 'nt' and self.plat_name != get_platform():
+            if self.plat_name == 'win-arm':
+                ext_suffix = '.cp37-win_arm.pyd'
+            elif self.plat_name == 'win-amd64':
+                ext_suffix = '.cp37-win_amd64.pyd'
+            elif self.plat_name == 'win32':
+                ext_suffix = '.cp37-win32.pyd'
+        else:
+            ext_suffix = get_config_var('EXT_SUFFIX')
+
         return os.path.join(*ext_path) + ext_suffix
 
     def get_export_symbols(self, ext):

--- a/Lib/distutils/command/build_ext.py
+++ b/Lib/distutils/command/build_ext.py
@@ -14,7 +14,7 @@ from distutils.sysconfig import customize_compiler, get_python_version
 from distutils.sysconfig import get_config_h_filename
 from distutils.dep_util import newer_group
 from distutils.extension import Extension
-from distutils.util import get_platform
+from distutils.util import get_platform, get_target_platform
 from distutils import log
 
 from site import USER_BASE
@@ -60,7 +60,7 @@ class build_ext(Command):
          "directory for temporary files (build by-products)"),
         ('plat-name=', 'p',
          "platform name to cross-compile for, if supported "
-         "(default: %s)" % get_platform()),
+         "(default: %s)" % get_target_platform()),
         ('inplace', 'i',
          "ignore build-lib and put compiled extensions into the source " +
          "directory alongside your pure Python modules"),
@@ -678,7 +678,8 @@ class build_ext(Command):
         """
         from distutils.sysconfig import get_config_var
         ext_path = ext_name.split('.')
-        
+
+        # TODO: make this less hard-coded
         if os.name == 'nt' and self.plat_name != get_platform():
             if self.plat_name == 'win-arm':
                 ext_suffix = '.cp37-win_arm.pyd'

--- a/Lib/distutils/command/build_ext.py
+++ b/Lib/distutils/command/build_ext.py
@@ -678,12 +678,7 @@ class build_ext(Command):
         """
         from distutils.sysconfig import get_config_var
         ext_path = ext_name.split('.')
-
-        if os.name == 'nt' and self.plat_name != get_platform():
-            plat_tag = self.plat_name.replace('-', '_')
-            ext_suffix = '.cp{0.major}{0.minor}-{1}.pyd'.format(sys.version_info, plat_tag)
-        else:
-            ext_suffix = get_config_var('EXT_SUFFIX')
+        ext_suffix = get_config_var('EXT_SUFFIX')
 
         return os.path.join(*ext_path) + ext_suffix
 

--- a/Lib/distutils/msvc9compiler.py
+++ b/Lib/distutils/msvc9compiler.py
@@ -22,7 +22,7 @@ from distutils.errors import DistutilsExecError, DistutilsPlatformError, \
 from distutils.ccompiler import CCompiler, gen_preprocess_options, \
                                 gen_lib_options
 from distutils import log
-from distutils.util import get_platform
+from distutils.util import get_platform, get_target_platform
 
 import winreg
 
@@ -49,7 +49,7 @@ else:
     WINSDK_BASE = r"Software\Microsoft\Microsoft SDKs\Windows"
     NET_BASE = r"Software\Microsoft\.NETFramework"
 
-# A map keyed by get_platform() return values to values accepted by
+# A map keyed by get_target_platform() return values to values accepted by
 # 'vcvarsall.bat'.  Note a cross-compile may combine these (eg, 'x86_amd64' is
 # the param to cross-compile on x86 targeting amd64.)
 PLAT_TO_VCVARS = {
@@ -341,7 +341,7 @@ class MSVCCompiler(CCompiler) :
         # multi-init means we would need to check platform same each time...
         assert not self.initialized, "don't init multiple times"
         if plat_name is None:
-            plat_name = get_platform()
+            plat_name = get_target_platform()
         # sanity check for platforms to prevent obscure errors later.
         ok_plats = 'win32', 'win-amd64'
         if plat_name not in ok_plats:

--- a/Lib/distutils/sysconfig.py
+++ b/Lib/distutils/sysconfig.py
@@ -15,6 +15,7 @@ import re
 import sys
 
 from .errors import DistutilsPlatformError
+from .util import get_platform, get_target_platform
 
 # These are needed in a couple of spots, so just compute them once.
 PREFIX = os.path.normpath(sys.prefix)
@@ -438,7 +439,14 @@ def _init_nt():
     # XXX hmmm.. a normal install puts include files here
     g['INCLUDEPY'] = get_python_inc(plat_specific=0)
 
-    g['EXT_SUFFIX'] = _imp.extension_suffixes()[0]
+    # if cross-compiling replace hardcoded platform-specific EXT_SUFFIX
+    # with an EXT_SUFFIX that matches the target platform
+    if get_platform() == get_target_platform():
+        g['EXT_SUFFIX'] = _imp.extension_suffixes()[0]
+    else:
+        plat_tag = get_target_platform().replace('-', '_')
+        g['EXT_SUFFIX'] = '.cp{0.major}{0.minor}-{1}.pyd'.format(sys.version_info, plat_tag)
+
     g['EXE'] = ".exe"
     g['VERSION'] = get_python_version().replace(".", "")
     g['BINDIR'] = os.path.dirname(os.path.abspath(sys.executable))

--- a/Lib/distutils/util.py
+++ b/Lib/distutils/util.py
@@ -94,6 +94,23 @@ def get_platform ():
 
 # get_platform ()
 
+def get_target_platform ():
+    TARGET_TO_PLAT = {
+        'x86' : 'win32',
+        'x64' : 'win-amd64',
+        'arm' : 'win-arm',
+    }
+
+    targetPlatformFromEnvironment = os.environ.get('VSCMD_ARG_TGT_ARCH')
+
+    if targetPlatformFromEnvironment != None and targetPlatformFromEnvironment in TARGET_TO_PLAT:
+        targetPlatform = TARGET_TO_PLAT[targetPlatformFromEnvironment]
+    else:
+        targetPlatform = get_platform()
+
+    return targetPlatform
+
+# get_target_platform ()
 
 def convert_path (pathname):
     """Return 'pathname' as a name that will work on the native filesystem,


### PR DESCRIPTION
Check the environment so that that --plat-name doesn't have to be passed in everywhere